### PR TITLE
Enhance assignment logic

### DIFF
--- a/primary/locales/en.json
+++ b/primary/locales/en.json
@@ -457,6 +457,7 @@
 			"erasePitAssignmentsAndData": "*WARNING:* Erases all pit scouting assignments and data for the current event.\n\nTo continue, enter your password.",
 			"permanentDeleteWarning": "By proceeding, you will be *permanently deleting* the data from *{number}* {type} scouting assignments from _{eventName}_. Are you sure you want to continue?",
 			"scoutingGroups": "Scouting groups",
+			"skipBreaks": "Check this box to generate assignments ignoring breaks in the schedule",
 			"submitNewGroup": "Submit selected members as a new scouting group",
 			"swapMatchAssignments": "Swap in/out match scouts",
 			"swapPitAssignments": "Swap teams between pit scout groups"

--- a/primary/views/manage/assignments/matches.pug
+++ b/primary/views/manage/assignments/matches.pug
@@ -38,6 +38,9 @@ block content
 				//- label &nbsp;matches
 				span(class="sprite sp-18 sp-help sp-inline w3-tooltip")
 					span(class="w3-tooltiptext w3-left-align")!=msgMarked('manage.assignments.blockSize.tooltipAssignees')
+				br
+				input(type="checkbox" class="w3-check" name='skipBreaks' id='skipBreaks')
+				label  !{msg('manage.assignments.skipBreaks')}&nbsp;
 
 				p
 				button(type="submit" class="w3-btn theme-submit")!=msg('manage.assignments.assignMatchTeams')


### PR DESCRIPTION
Incorporates three fixes/updates:

- Update the "queue order" of available scouts to sort first by how many matches scouts have already done, *then* by seniority value
- Handle less than six scouters; includes balancing the scout-team assignments so teams are scouted roughly even amounts
- Add option to do schedule scouts to matches for an entire event (ignoring breaks)
