### PR TITLE
Changed to 'latest timestamp' + 1 second

### DIFF
--- a/primary/src/routes/manage/scoutingaudit.ts
+++ b/primary/src/routes/manage/scoutingaudit.ts
@@ -40,23 +40,24 @@ router.get('/', wrap(async (req, res) =>  {
 	let event_key = req.event.key;
 	let org_key = req._user.org_key;
 
-	let matches: Match[] = await utilities.find('matches', { event_key: event_key, 'alliances.red.score': -1 }, {sort: {'time': 1}});
+	// 2024-01-27, M.O'C: Switch to *max* time of *resolved* matches [where alliance scores != -1]
+	let matches: Match[] = await utilities.find('matches', { event_key: event_key, 'alliances.red.score': {$ne: -1} }, {sort: {'time': -1}});
 	
 	// 2018-03-13, M.O'C - Fixing the bug where dashboard crashes the server if all matches at an event are done
-	let earliestTimestamp = 9999999999;
+	let latestTimestamp = 9999999999;
 	if (matches && matches[0]) {
-		let earliestMatch = matches[0];
-		earliestTimestamp = earliestMatch.time;
+		let latestMatch = matches[0];
+		latestTimestamp = latestMatch.time + 1;
 	}
 	
-	logger.debug(`Scoring audit: earliestTimestamp=${earliestTimestamp}, earliest match=${matches[0]?.key}`);
+	logger.debug(`Scoring audit: latestTimestamp=${latestTimestamp}, latest match=${matches[0]?.key}`);
 	
 	// 2020-02-11, M.O'C: Renaming "scoringdata" to "matchscouting", adding "org_key": org_key, 
 	let scoreData: MatchScouting[] = await utilities.find('matchscouting', 
 		{
 			org_key, 
 			event_key, 
-			'time': { $lt: earliestTimestamp }
+			'time': { $lt: latestTimestamp }
 		}, 
 		{ 
 			sort: {'assigned_scorer.name': 1, 'time': 1, 'alliance': 1, 'team_key': 1} 
@@ -297,20 +298,21 @@ router.get('/bymatch', wrap(async (req, res) => {
 	let org_key = req._user.org_key;
 
 	// Get the *min* time of the as-yet-unresolved matches [where alliance scores are still -1]
-	let matches: Match[] = await utilities.find('matches', {event_key: eventKey, 'alliances.red.score': -1}, {sort: {'time': 1}});
+	// 2024-01-27, M.O'C: Switch to *max* time of *resolved* matches [where alliance scores != -1]
+	let matches: Match[] = await utilities.find('matches', {event_key: eventKey, 'alliances.red.score': {$ne: -1}}, {sort: {'time': -1}});
 	
 	// 2018-03-13, M.O'C - Fixing the bug where dashboard crashes the server if all matches at an event are done
-	let earliestTimestamp = 9999999999;
+	let latestTimestamp = 9999999999;
 	
 	if (matches[0]){
-		let earliestMatch = matches[0];
-		earliestTimestamp = earliestMatch.time;
+		let latestMatch = matches[0];
+		latestTimestamp = latestMatch.time + 1;
 	}
 	
-	logger.debug('Per-match audit: earliestTimestamp=' + earliestTimestamp);
+	logger.debug('Per-match audit: latestTimestamp=' + latestTimestamp);
 	
 	// 2020-02-11, M.O'C: Renaming "scoringdata" to "matchscouting", adding "org_key": org_key, 
-	let scoreData: MatchScouting[] = await utilities.find('matchscouting', {'org_key': org_key, 'event_key': eventKey, 'time': { $lt: earliestTimestamp }}, { sort: {'time': 1, 'alliance': 1, 'team_key': 1} });
+	let scoreData: MatchScouting[] = await utilities.find('matchscouting', {'org_key': org_key, 'event_key': eventKey, 'time': { $lt: latestTimestamp }}, { sort: {'time': 1, 'alliance': 1, 'team_key': 1} });
 	
 	//Create array of matches for audit, with each match-team inside each match
 	let audit = [];
@@ -371,22 +373,23 @@ router.get('/comments', wrap(async (req, res) => {
 	let org_key = req._user.org_key;
 		
 	// Get the *min* time of the as-yet-unresolved matches [where alliance scores are still -1]
-	let matches: Match[] = await utilities.find('matches', {event_key: event_key, 'alliances.red.score': -1}, {sort: {'time': 1}});
+	// 2024-01-27, M.O'C: Switch to *max* time of *resolved* matches [where alliance scores != -1]
+	let matches: Match[] = await utilities.find('matches', {event_key: event_key, 'alliances.red.score': {$ne: -1}}, {sort: {'time': -1}});
 	
 	// 2018-03-13, M.O'C - Fixing the bug where dashboard crashes the server if all matches at an event are done
-	let earliestTimestamp = 9999999999;
+	let latestTimestamp = 9999999999;
 	
 	if (matches[0]){
-		let earliestMatch = matches[0];
-		earliestTimestamp = earliestMatch.time;
+		let latestMatch = matches[0];
+		latestTimestamp = latestMatch.time + 1;
 	}
 	
-	logger.debug('Comments audit: earliestTimestamp=' + earliestTimestamp);
+	logger.debug('Comments audit: latestTimestamp=' + latestTimestamp);
 		
 	// 2020-02-11, M.O'C: Renaming "scoringdata" to "matchscouting", adding "org_key": org_key, 
 	// 2023-02-13 JL: Added the otherNotes check into the DB query instead of a JS loop later
 	let scoreData: MatchScouting[] = await utilities.find('matchscouting', 
-		{org_key, event_key, time: { $lt: earliestTimestamp }, 'data.otherNotes': {$regex: '.+'}}, 
+		{org_key, event_key, time: { $lt: latestTimestamp }, 'data.otherNotes': {$regex: '.+'}}, 
 		{ sort: {'actual_scorer.name': 1, 'time': 1, 'alliance': 1, 'team_key': 1} }
 	);
 	


### PR DESCRIPTION
Most of the timestamp logic was originally "greater than **or equal to** the _earliest unplayed_ timestamp"

I left the operators '$gte' ('greater than or equal to'), but switched the queries to return the _latest played_ timestamp **plus one second**. By adding one (1) second we ensure downstream logic still works regardless.  