### PR TITLE
Added maintenance mode toggle via proccess.env.MAINTENANCE

### DIFF
--- a/primary/src/app.ts
+++ b/primary/src/app.ts
@@ -99,6 +99,8 @@ app.get('/*', (req, res, next) => {
 //Must be the very first app.use
 app.use(utilities.refreshTier);
 
+app.use(usefunctions.maintenanceMode);
+
 //Boilerplate setup
 app.set('views', path.join(__dirname, '..', 'views'));
 app.set('view engine', 'pug');

--- a/primary/src/helpers/usefunctions.ts
+++ b/primary/src/helpers/usefunctions.ts
@@ -533,6 +533,18 @@ class UseFunctions {
 		
 		logger.removeContext('funcName');
 	}
+	
+	/**
+	 * Checks process.env.MAINTENANCE to see if the site should be in maintenance mode and if so, renders some plain text
+	 */
+	static maintenanceMode(req: express.Request, res: express.Response, next: express.NextFunction) {
+		if (process.env.MAINTENANCE === 'true') {
+			return res.status(503).send('The site is currently undergoing some maintenance. Check back in a few minutes.');
+		}
+		else {
+			return next();
+		}
+	}
 }
 
 module.exports = UseFunctions;


### PR DESCRIPTION
When we're doing a database upgrade, we should temporarily disable people from using the site. We can set the MAINTENANCE environment variable to `true` inside the AWS Lambda console when we need to some database maintenance, then unset it when we're done.