### PR TITLE
Update utilities' castID function to cast _id to a number depending on the collection

### DIFF
--- a/scoutradioz-utilities/types/utilities.d.ts
+++ b/scoutradioz-utilities/types/utilities.d.ts
@@ -299,9 +299,9 @@ export declare class Utilities {
     private dbLock;
     private open;
     /**
-     * Fix filter queries by replacing String IDs with the proper ObjectID
+     * Fix filter queries by replacing String IDs with the proper ID type of the specified collection
      * @param query Query with or without _id
-     * @returns Query with _id replaced with an ObjectId
+     * @returns Query with _id replaced with an ObjectId or number, depending on the collection
      */
     private castID;
 }


### PR DESCRIPTION
I missed a route in /manage/members that didn't do parseInt on the _id for User, meaning the update call didn't actually update the members' details. This'll auto-cast strings to numbers in the _id of the query filter, for collections specified to have numerical IDs (currently, just users)