### PR TITLE
Enabled the match and pit routes to accept a specific fake team, added buttons and nav options

### DIFF
--- a/primary/locales/en.json
+++ b/primary/locales/en.json
@@ -116,7 +116,10 @@
 		"scoutingDashboard": "Scouting dashboard",
 		"management": "Management",
 		"admin": "Admin",
-		"specifyTeam": "You must specify a team."
+		"specifyTeam": "You must specify a team.",
+		"formDemos": "Review the forms",
+		"matchFormDemo": "Match form",
+		"pitFormDemo": "Pit form"
 	},
 	"thankyou": {
 		"title": "Thank you!",

--- a/primary/locales/en.json
+++ b/primary/locales/en.json
@@ -117,7 +117,7 @@
 		"management": "Management",
 		"admin": "Admin",
 		"specifyTeam": "You must specify a team.",
-		"formDemos": "Review the forms",
+		"formDemos": "Preview the forms",
 		"matchFormDemo": "Match form",
 		"pitFormDemo": "Pit form"
 	},

--- a/primary/src/helpers/nav.ts
+++ b/primary/src/helpers/nav.ts
@@ -192,6 +192,19 @@ class NavHelpers {
 				{
 					label: '!allianceselection.title',
 					href: '/dashboard/allianceselection',
+				},
+				{
+					label: '!home.formDemos',
+					submenu: [
+						{
+							label: '!home.matchFormDemo',
+							href: '/scouting/match?key=2024srdemo_qm99_frc999999&alliance=Blue'
+						},
+						{
+							label: '!home.pitFormDemo',
+							href: '/scouting/pit?team_key=frc999999'
+						},
+					]
 				}
 			]
 		},

--- a/primary/src/routes/scouting.ts
+++ b/primary/src/routes/scouting.ts
@@ -33,7 +33,9 @@ router.get('/match*', wrap(async (req, res) => {
 	let org_key = thisUser.org_key;
 	if (typeof match_team_key !== 'string') throw new e.UserError(req.msg('scouting.invalidMatchKey')); // 2022-05-17 JL: Throw if they don't have a match key set in the url OR if they set two, making it an array
 	let teamKey = match_team_key.split('_')[2];
-	
+	// 2024-02-29, M.O'C: special case, we're going to handle "frc999999" for form demo purposes
+	const demoTeamKey = 'frc999999';
+
 	logger.debug(`match_team_key: ${match_team_key} alliance: ${alliance} user: ${thisUserName} teamKey=${teamKey}`);
 	
 	if (!match_team_key) {
@@ -72,8 +74,31 @@ router.get('/match*', wrap(async (req, res) => {
 	
 	
 	const images = await uploadHelper.findTeamImages(org_key, eventYear, teamKey);
-	const team: Team = await utilities.findOne('teams', {key: teamKey}, {}, {allowCache: true});
+	let team: Team = await utilities.findOne('teams', {key: teamKey}, {}, {allowCache: true});
 	
+	// 2024-02-29, M.O'C: if the teamKey is the same as the demoTeamKey, set the 'team' 
+	if (teamKey == demoTeamKey)
+		team = {
+			address: null,
+			city: 'DN', 
+			country: null,
+			gmaps_place_id: null,
+			gmaps_url: null,
+			key: 'frc999999',
+			lat: null,
+			lng: null,
+			location_name: null,
+			motto: null,
+			name: 'DNGN999999',
+			nickname: 'DNGN999999',
+			postal_code: null,
+			rookie_year: null,
+			school_name: null,
+			state_prov: 'GN',
+			team_number: 999999,
+			website: null
+		};
+
 	if (!team) throw new e.UserError(req.msg('scouting.invalidTeam', {team: teamKey}));
 
 	let allianceLocale = (alliance.toLowerCase().startsWith('b')) ? req.msg('alliance.blueShort') : req.msg('alliance.redShort');
@@ -290,6 +315,8 @@ router.get('/pit*', wrap(async (req, res) => {
 	let org_key = req._user.org_key;
 
 	let teamKey = req.query.team_key;
+	// 2024-02-29, M.O'C: special case, we're going to handle "frc999999" for form demo purposes
+	const demoTeamKey = 'frc999999';
 	
 	if (typeof teamKey !== 'string') throw new e.UserError(req.msg('scouting.invalidTeamKey'));
 		
@@ -310,7 +337,29 @@ router.get('/pit*', wrap(async (req, res) => {
 			
 	const images = await uploadHelper.findTeamImages(org_key, event_year, teamKey);
 	
-	const team: Team = await utilities.findOne('teams', {key: teamKey}, {}, {allowCache: true});
+	let team: Team = await utilities.findOne('teams', {key: teamKey}, {}, {allowCache: true});
+	// 2024-02-29, M.O'C: if the teamKey is the same as the demoTeamKey, set the 'team' 
+	if (teamKey == demoTeamKey)
+		team = {
+			address: null,
+			city: 'DN', 
+			country: null,
+			gmaps_place_id: null,
+			gmaps_url: null,
+			key: 'frc999999',
+			lat: null,
+			lng: null,
+			location_name: null,
+			motto: null,
+			name: 'DNGN999999',
+			nickname: 'DNGN999999',
+			postal_code: null,
+			rookie_year: null,
+			school_name: null,
+			state_prov: 'GN',
+			team_number: 999999,
+			website: null
+		};
 	
 	res.render('./scouting/pit', {
 		title: req.msg('scouting.pit'),

--- a/primary/views/home.pug
+++ b/primary/views/home.pug
@@ -66,6 +66,14 @@ block content
 			div(class="gear-btn theme-link w3-btn")
 				span!=msg('layout.nav.voyager')
 
+	if user.role && user.role.access_level >= Permissions.ACCESS_SCOUTER
+		div(class="w3-container w3-section")
+			h4(class="theme-text")!=msg('home.formDemos')
+			a(href="/scouting/match?key=2024srdemo_qm99_frc999999&alliance=Blue")
+				div(class="gear-btn theme-link w3-btn")!=msg('home.matchFormDemo')
+			a(href="/scouting/pit?team_key=frc999999")
+				div(class="gear-btn theme-link w3-btn")!=msg('home.pitFormDemo')
+
 	script.
 		$(function(){
 			//If user presses back button and teamselect is populated, gotta un-disable stats btn


### PR DESCRIPTION
Mimicking the "validate form JSON" views, this change allows the 'special' team key "frc999999" to go through as a 'fake' team.

This will allow team members to see the match and pit scouting forms without needing to generate assignments at an event and so forth.

They don't need to hit "submit", but if they do, hitting "submit" doesn't error but also doesn't write anything to the DB. (It _will_ redirect them to the scouting dashboard)