### PR TITLE
Improve "WIP - Browse events"

### DIFF
--- a/primary/locales/en.json
+++ b/primary/locales/en.json
@@ -339,6 +339,7 @@
 		"allTeams": "all teams",
 		"allianceStats": "Alliance team statistics",
 		"allTeamMetrics": "All team metrics",
+		"browsePastEvents": "Browse data from past events",
 		"completedMatches": "Completed matches",
 		"upcomingMatches": "Upcoming matches",
 		"upcomingMatchesTeam": "Upcoming matches for {team}",
@@ -495,5 +496,6 @@
 	"add": "Add",
 	"class": "Class",
 	"subteam": "Subteam",
-	"update": "Update"
+	"update": "Update",
+	"year": "Year"
 }

--- a/primary/src/helpers/nav.ts
+++ b/primary/src/helpers/nav.ts
@@ -125,7 +125,7 @@ class NavHelpers {
 						href: '/reports/allteammetrics',
 					},
 					{
-						label: 'WIP - Browse data from other events',
+						label: '!reports.browsePastEvents',
 						href: '/reports/browseevents',
 					},
 					{

--- a/primary/src/routes/reports.ts
+++ b/primary/src/routes/reports.ts
@@ -40,10 +40,10 @@ router.get('/browseevents', wrap(async (req, res) => {
 		if (!event_keys.includes(key)) event_keys.push(key);
 	});
 	
-	const events = await utilities.find('events', {key: {$in: event_keys}});
+	const events = await utilities.find('events', {key: {$in: event_keys}}, {sort: {start_date: 1}});
 	
 	res.render('./reports/browseevents', {
-		title: 'WIP - Browse events',
+		title: req.msg('reports.browsePastEvents'),
 		events
 	});
 }));

--- a/primary/views/reports/browseevents.pug
+++ b/primary/views/reports/browseevents.pug
@@ -2,7 +2,14 @@ extends ../layout
 block content
 	h2=title
 	h6 Below is a list of all events for which your org has data.
-	ul
+	table(class="w3-table w3-bordered")
+		tr
+			th!=msg('year')
+			th!=msg('date')
+			th(style="width: 60%")!=msg('name')
 		each event in events
-			li 
-				a(class="link" href=`/reports/browseevent?event_key=${event.key}`) #{event.name}
+			tr
+				td(class="w3-padding-16")=event.year
+				td(class="w3-padding-16")=event.start_date
+				td(class="w3-padding-16")
+					a(class="link" href=`/reports/browseevent?event_key=${event.key}`)=event.name


### PR DESCRIPTION
Made the page show the event year, and sorted them by date, and added the page title to the locale file. The feature itself has been fairly well tested and seems to be working reliably.