### PR TITLE
Fixed match scheduling not working during/past first break

### DIFF
--- a/primary/src/routes/manage/assignments.ts
+++ b/primary/src/routes/manage/assignments.ts
@@ -487,6 +487,8 @@ router.post('/matches/generate', wrap(async (req, res) => {
 		scoutsPerMatch = matchScoutsPlusScoutedCount.length;
 	}
 
+	// 2024-03-20, M.O'C: The changes to "use latest timestamp" instead of "next unplayed timestamp" broke scheduling when you're doing the 2nd run past breaks
+	let notFirstMatch: boolean = false;
 	for (let matchesIdx in comingMatches) {
 		const thisMatch = comingMatches[matchesIdx];
 		const thisMatchKey = thisMatch.key;
@@ -532,11 +534,13 @@ router.post('/matches/generate', wrap(async (req, res) => {
 			matchGap = comingMatches[matchesIdx].time - lastMatchTimestamp;
 		// Iterate until a "break" is found (or otherwise, if the loop is exhausted)
 		// 2024-01-24, M.O'C: Might optionally not be stopping for breaks
-		if (stoppingForBreaks)
+		// 2024-03-20, M.O'C: Only check for breaks on the 2nd and later matches - 'notFirstMatch' is initially "false"
+		if (stoppingForBreaks && notFirstMatch)
 			if (matchGap > matchGapBreakThreshold) {
 				logger.trace('matchGap=' + matchGap + '... found a break');
 				break;
 			}
+		notFirstMatch = true;
 		
 		let teamArray: TeamKey[] = [];
 		if (redBlueToggle == 0)


### PR DESCRIPTION
The match assignments, when "assign up to the next break", would only work at the start of the event; **during** _(or after)_ that first break, match assignments "up to the following break" did not work. You'd have to check the box to ignore the breaks.

This is because of the change from "timestamp of next unplayed match" to "timestamp of last played match". Now, during the first break, the last played match was automatically 'large break' away from the next unplayed match.

Fix is to not check for the gap on the 1st unplayed match (since presumably we **expect** it to be 'large break' away), only on the subsequent matches. 