### PR TITLE
Added playoff scouting; also fixed bug in reassignmenrs

### DIFF
--- a/primary/locales/en.json
+++ b/primary/locales/en.json
@@ -186,7 +186,7 @@
 	"scouting": {
 		"match": "Match scouting",
 		"pit": "Pit scouting",
-		"supermatch": "Super scout match {n}",
+		"supermatch": "Super scout this match",
 		"superpit": "Super scout",
 		"supermatchnotes": "Super scout match notes:",
 		"supernotes": "Super scout notes for team {team}:",
@@ -241,6 +241,8 @@
 		"pitScoutingPartner": "Partner's pit scouting assignments",
 		"upcomingMatches": "Upcoming matches to be scouted",
 		"matchNumber": "Match {number}",
+		"sfNumber": "Semifinal {number}",
+		"fNumber": "Final {number}",
 		"matchResultMissedWarning": "WARNING: A match result may have been missed!",
 		"matchResultMissedAdmin": "Click here, check FIRST match data and update any missing matches.",
 		"matchResultMissedNotAdmin": "Ask a team admin to check FIRST match data and update any missing matches.",
@@ -493,6 +495,7 @@
 			"permanentDeleteWarning": "By proceeding, you will be *permanently deleting* the data from *{number}* {type} scouting assignments from _{eventName}_. Are you sure you want to continue?",
 			"scoutingGroups": "Scouting groups",
 			"skipBreaks": "Check this box to generate assignments ignoring breaks in the schedule",
+			"scoutPlayoffs": "Check this box to generate assignments for playoff matches as well",
 			"submitNewGroup": "Submit selected members as a new scouting group",
 			"swapMatchAssignments": "Swap in/out match scouts",
 			"swapPitAssignments": "Swap teams between pit scout groups"

--- a/primary/src/routes/manage/assignments.ts
+++ b/primary/src/routes/manage/assignments.ts
@@ -195,19 +195,27 @@ router.post('/matches/generate', wrap(async (req, res) => {
 	
 	const availableArray: number[] = []; // User IDs
 	let stoppingForBreaks = true;
+	let scoutPlayoffs = false;
 	logger.trace('*** Tagged as available:');
 	for(let user in req.body) {
 		const userId = user.split('|')[0];
 		// 2024-01-24, M.O'C: special case, checkbox to 'skipBreaks'
-		if (userId != 'skipBreaks') { 
+		// 2024-04-04, M.O'C: Enable option to assign scouting to playoffs
+		if (userId != 'skipBreaks' && userId != 'scoutPlayoffs') { 
 			const userName = user.split('|')[1]; // unused
 			logger.trace(`user: ${userId} | ${userName}`);
 			assert(userId && userName, 'Could not find both userId and userName');
 			availableArray.push(Number(userId));
 		}
 		else {
-			logger.debug('Assignments will continue past breaks!');
-			stoppingForBreaks = false;
+			if (userId === 'skipBreaks') {
+				logger.debug('Assignments will continue past breaks!');
+				stoppingForBreaks = false;
+			}
+			else if (userId === 'scoutPlayoffs') {
+				logger.debug('Assignments will be generated for playoffs!');
+				scoutPlayoffs = true;
+			}
 		}
 	}
 	
@@ -215,11 +223,22 @@ router.post('/matches/generate', wrap(async (req, res) => {
 		{org_key, event_key},
 		{sort: {time: 1}}
 	);
-	
-	const matchArray: Match[] = await utilities.find('matches', 
-		{event_key, comp_level: 'qm'},
-		{sort: {time: 1}}
-	);
+
+	let matchArray: Match[] = [];
+	if (scoutPlayoffs) {
+		// 2024-04-04, M.O'C: Do not filter on 'comp_level'
+		matchArray = await utilities.find('matches', 
+			{event_key},
+			{sort: {time: 1}}
+		);
+	}
+	// most of the time only scout quals
+	else {
+		matchArray = await utilities.find('matches', 
+			{event_key, comp_level: 'qm'},
+			{sort: {time: 1}}
+		);
+	}
 	
 	let outputNotes: string[] = []; // Notes to display to the scouting lead about what went on behind the scenes
 	
@@ -327,8 +346,11 @@ router.post('/matches/generate', wrap(async (req, res) => {
 			logger.info('There are existing assignments in the DB, so we will attempt to re-populate existing data when re-generating...');
 			
 			// Populate a dict of all the existing data for the match
+			// 2024-04-04, M.O'C: Carrying over assigned scorer (and) super_data
 			const matchTeamKeyToSubmissionsMap: Dict<{
 				data: MatchFormData;
+				super_data?: MatchFormData;
+				assigned_scorer?: ScouterRecord;
 				actual_scorer?: ScouterRecord;
 				useragent?: UserAgent;
 			}> = {};
@@ -337,6 +359,8 @@ router.post('/matches/generate', wrap(async (req, res) => {
 				if (matchTeam.data) {
 					matchTeamKeyToSubmissionsMap[matchTeam.match_team_key] = {
 						data: matchTeam.data,
+						super_data: matchTeam.super_data,
+						assigned_scorer: matchTeam.assigned_scorer,
 						actual_scorer: matchTeam.actual_scorer,
 						useragent: matchTeam.useragent,
 					};
@@ -356,6 +380,9 @@ router.post('/matches/generate', wrap(async (req, res) => {
 					// JL note: actual_scouter and useragent could be undefined, so I'd rather not add the keys unless they're defined
 					if (thisSubmission.actual_scorer) matchTeam.actual_scorer = thisSubmission.actual_scorer;
 					if (thisSubmission.useragent) matchTeam.useragent = thisSubmission.useragent;
+					// 2024-04-04, M.O'C: Add in preserving assigned_scorer (and) super_data
+					if (thisSubmission.super_data) matchTeam.super_data = thisSubmission.super_data;
+					if (thisSubmission.assigned_scorer) matchTeam.assigned_scorer = thisSubmission.assigned_scorer;
 					// Now, delete the key from the submissions map so we can keep track of which entries have NOT yet been repopulated into the new array
 					delete matchTeamKeyToSubmissionsMap[matchTeam.match_team_key];
 				}

--- a/primary/views/dashboard/index.pug
+++ b/primary/views/dashboard/index.pug
@@ -41,7 +41,10 @@ block content
 				- match.alliance = (match.alliance == "red") ? "Red" : "Blue";
 				- var btnColor = (match.alliance == "Red") ? "alliance-red" : "alliance-blue"
 				
-				h4 !{msg('dashboard.matchNumber', {number: match.match_number})} <br/> #{zoneTime(match.time * 1000).toFormat('cccc @ t')} 
+				- var matchMsg =  msg('dashboard.matchNumber', {number: match.match_number})
+				- if (match.comp_level == 'sf') matchMsg =  msg('dashboard.sfNumber', {number: match.set_number})
+				- if (match.comp_level == 'f') matchMsg =  msg('dashboard.fNumber', {number: match.match_number})
+				h4 !{matchMsg} <br/> #{zoneTime(match.time * 1000).toFormat('cccc @ t')} 
 					if match.data
 						a(href=`/scouting/match?key=${match.match_team_key}&alliance=${match.alliance}`) 
 							div(class="gear-btn theme-dim w3-btn w3-section w3-margin-left w3-margin-right")

--- a/primary/views/dashboard/matches.pug
+++ b/primary/views/dashboard/matches.pug
@@ -35,7 +35,10 @@ block content
 					div(class="w3-col m6 l4 w3-padding")
 						hr
 						div(class="w3-col w3-padding")
-							span !{msg('dashboard.matchNumber', {number: match.match_number})} <br/> #{zoneTime(match.time * 1000).toFormat('cccc @ t')}
+							- var matchMsg =  msg('dashboard.matchNumber', {number: match.match_number})
+							- if (match.comp_level == 'sf') matchMsg =  msg('dashboard.sfNumber', {number: match.set_number})
+							- if (match.comp_level == 'f') matchMsg =  msg('dashboard.fNumber', {number: match.match_number})
+							span !{matchMsg} <br/> #{zoneTime(match.time * 1000).toFormat('cccc @ t')}
 						each assignment, j in assignments
 							- assignment.alliance = (assignment.alliance == "red") ? "Red" : "Blue";
 							div(class="w3-col" style="height: 55px; display: flex;")

--- a/primary/views/manage/assignments/matches.pug
+++ b/primary/views/manage/assignments/matches.pug
@@ -41,6 +41,9 @@ block content
 				br
 				input(type="checkbox" class="w3-check" name='skipBreaks' id='skipBreaks')
 				label  !{msg('manage.assignments.skipBreaks')}&nbsp;
+				p
+				input(type="checkbox" class="w3-check" name='scoutPlayoffs' id='scoutPlayoffs')
+				label  !{msg('manage.assignments.scoutPlayoffs')}&nbsp;
 
 				p
 				button(type="submit" class="w3-btn theme-submit")!=msg('manage.assignments.assignMatchTeams')

--- a/primary/views/scouting/supermatch.pug
+++ b/primary/views/scouting/supermatch.pug
@@ -21,6 +21,8 @@ block content
 			- let this_match_team_key = data.match_team_key;
 			- let this_team_key = data.team_key;
 			- var titleParts = this_match_team_key.split('_').map(key => key.replace(/\D/g, '')); // 2022mrcmp_qm77_frc102 to ['2022', '77', '102']
+			- if (this_match_team_key.split('_')[1].substring(0, 2) == 'sf') titleParts[1] = (this_match_team_key.split('_')[1].split('m').map(key => key.replace(/\D/g, '')))[0]; // 2022mrcmp_sf4m1_frc102 to '4'
+			- if (this_match_team_key.split('_')[1].substring(0, 1) == 'f') titleParts[1] = (this_match_team_key.split('_')[1].split('m').map(key => key.replace(/\D/g, '')))[1]; // 2022mrcmp_f1m2_frc102 to '2'
 			- let element = {"year":{"$numberInt":titleParts[0]},"order":"1","type":"textblock","label":"Super-Scout Notes","id":`${this_team_key}_otherNotes`,"org_key":org_key,"form_type":"supermatchscouting"}
 			- var btnColor = data.alliance ? ((data.alliance.toLowerCase().startsWith('r')) ? "alliance-red" : "alliance-blue") : '';
 			p


### PR DESCRIPTION
- Added a checkbox to optionally scout playoff matches (if they exist)
- Also updated pages to display the 'tag' of playoff matches correctly ("Semifinal 3", "Final 2", etc.)
- While in here, also fixed a bug in regenerating assignments that could erase 'assigned_scouter' _(needed for per-scouter audit)_ and 'super_data' _(wanting to preserve previous super-scouting notes)_