### PR TITLE
Improved multi-team org support

### DIFF
--- a/primary/locales/en.json
+++ b/primary/locales/en.json
@@ -267,6 +267,7 @@
 		"chooseTeam": "[Choose a team]",
 		"viewOr": "or",
 		"allTeams": "All teams",
+		"otherTeams": "Other teams",
 		"selectedTeam": "Selected team",
 		"nextMatch": "Next match:",
 		"nextMatchTeam": "Next match for team {team}:",
@@ -295,7 +296,9 @@
 		"team": "Team",
 		"rank": "FRC Rank",
 		"numAlliances": "Number of alliances:",
-		"numRounds": "Number of rounds:"
+		"numRounds": "Number of rounds:",
+		"tooltipPicklist": "Each FRC team in an organization has their own picklist. Pick which team's picklist to view.",
+		"choosePicklist": "View picklist for..."
 	},
 	"metrics": {
 		"raw": "Raw data",
@@ -496,6 +499,17 @@
 			"submitNewGroup": "Submit selected members as a new scouting group",
 			"swapMatchAssignments": "Swap in/out match scouts",
 			"swapPitAssignments": "Swap teams between pit scout groups"
+		},
+		"config": {
+			"title": "Configure {org}",
+			"tooltipSubteamKey": "Write a unique identifier for each subteam. After you create a subteam, the label can change but the key should not change.",
+			"tooltipClassKey": "Write a unique identifier for each class. After you create a class, the label can change but the key should not change.",
+			"tooltipTeams": "Place the number of all FRC teams associated with this organization, separated by a comma. There can be multiple if your organization is a scouting collective, or if your team is pooling scouters with another FRC team.",
+			"invalidTeams": "Could not find a team with the number \"{number}\". Please enter a comma-separated list of FRC team numbers.",
+			"updatedSuccessfully": "Updated successfully.",
+			"updatedButFixSubteams": "Org config has updated, but one or more users will need to be updated due to subteam / class keys changing.\n- *Go through the list of users and make sure everyone has a subteam and class.\n- Click 'Update' for each user that has been updated.*",
+			"id": "ID",
+			"teams": "Team(s)"
 		}
 	},
 	"date": "Date",

--- a/primary/public-src/ts-bundled/FormSubmission.ts
+++ b/primary/public-src/ts-bundled/FormSubmission.ts
@@ -29,7 +29,7 @@ class FormSubmission{
 	constructor(form: HTMLFormElement|JQuery, url: string, key: string, options?: {autoRetry: boolean}){
 		
 		if (form && url && key) {
-			this.data = this._getFormData(form);
+			this.data = FormSubmission.getFormData(form);
 			this.url = url;
 			this.key = key; //Date.now().toString();
 			
@@ -104,7 +104,10 @@ class FormSubmission{
 		localStorage.setItem(this.key, JSON.stringify(this.data));
 	}
 	
-	_getFormData(form: HTMLFormElement|JQuery){
+	/**
+	 * Get a key-value object from any form element (useful outside of the FormSubmission class)
+	 */
+	static getFormData(form: HTMLFormElement|JQuery) {
 		let unIndexedData = $(form).serializeArray();
 		let indexedData: Dictionary<string> = {};
 	

--- a/primary/public-src/ts/bundle.d.ts
+++ b/primary/public-src/ts/bundle.d.ts
@@ -59,7 +59,10 @@ declare class FormSubmission {
     submit(cb: ObjectCallback): void;
     _getFromLocalStorage(): string | null;
     _addToLocalStorage(): void;
-    _getFormData(form: HTMLFormElement | JQuery): Dictionary<string>;
+    /**
+     * Get a key-value object from any form element (useful outside of the FormSubmission class)
+     */
+    static getFormData(form: HTMLFormElement | JQuery): Dictionary<string>;
 }
 interface ObjectCallback {
     (error: JQueryXHR | Error | string | null, response?: SRResponse): void;

--- a/primary/public-src/ts/script-allianceselection.ts
+++ b/primary/public-src/ts/script-allianceselection.ts
@@ -81,11 +81,8 @@ $(function(){
 	$('[team-key]').on('click', function() {
 		let team_key = $(this).attr('team-key');
 		Dialog.showURL(`/reports/teamintel?team_key=${team_key}`);
-		// for now, just fetch their team intel page
-		// fetch(`/reports/teamintel?team_key=${team_key}`)
-		// 	.then(data => data.text())
-		// 	.then(html => Dialog.show(html));
 	});
+	
 });
 
 function doNumChange(el: Element, param: string) {

--- a/primary/src/routes/dashboard.ts
+++ b/primary/src/routes/dashboard.ts
@@ -33,14 +33,31 @@ router.get('/driveteam', wrap(async (req, res) => {
 	
 	//set teamKey to query or org default
 	// 2022-03-16 JL: Adding an "all" button
+	// 2024-04-04 JL: Added cookie to store which team key (of the team keys in the org) we think the user belongs to
+	let teamKeyCookie = req.cookies['selectedTeamKey'];
 	if (typeof req.query.team_key === 'string' && !req.query.all) {
 		teamKey = req.query.team_key;
+		if (thisUser.org.team_keys?.includes(teamKey)) {
+			logger.debug('Setting teamKey cookie from query parameter because it\'s in the org\'s list of team_keys');
+			res.cookie('selectedTeamKey', teamKey);
+		}
+	}
+	else if (teamKeyCookie && thisUser.org.team_keys?.includes(teamKeyCookie)) {
+		logger.debug(`Setting teamKey to ${teamKeyCookie} from cookie`);
+		teamKey = teamKeyCookie;
 	}
 	else if (thisUser.org.team_key && !req.query.all) {
+		logger.debug(`Setting teamKey ${teamKey} from org team key`);
 		teamKey = thisUser.org.team_key;
 	}
 	else {
 		teamKey = 'all';
+	}
+	
+	// Remove team key cookie if it's set but isn't inside the list of team_keys the org has
+	if (teamKeyCookie && !thisUser.org.team_keys?.includes(teamKeyCookie)) {
+		logger.info(`teamKeyCookie ${teamKeyCookie} not in list of org keys; removing cookie`);
+		res.clearCookie('selectedTeamKey');
 	}
 	
 	logger.debug(`eventKey=${eventKey} orgKey=${orgKey} teamKey=${teamKey}`);
@@ -215,6 +232,10 @@ router.get('/driveteam', wrap(async (req, res) => {
 		}
 	}
 	
+	let orgTeamKeys = [];
+	if (req._user.org.team_key) orgTeamKeys.push(req._user.org.team_key);
+	if (req._user.org.team_keys) orgTeamKeys.push(...req._user.org.team_keys);
+	
 	res.render('./dashboard/driveteam', {
 		title: res.msg('driveDashboard.title'),
 		teamList: teamList,
@@ -227,6 +248,7 @@ router.get('/driveteam', wrap(async (req, res) => {
 		teamRanks: teamRanks,
 		selectedTeam: teamKey,
 		teamNumbers: teamNumbers,
+		orgTeamKeys,
 		noMatchesFoundForTeam: noMatchesFoundForTeam,
 		dataForChartJS: JSON.stringify(dataForChartJS),
 		pitData: pitData
@@ -425,16 +447,19 @@ router.get('/allianceselection', wrap(async (req, res) => {
 	let numRounds = typeof req.query.numRounds === 'string'
 		? parseInt(req.query.numRounds) : 3;
 	logger.debug(`numAlliances: ${numAlliances}, numRounds: ${numRounds}`);
-
-	// if (numAlliances < 2) throw new e.UserError('invalid numAlliances');
-	// if (numRounds < 2 || 4 < numRounds) throw new e.UserError('invalid numRounds');
+	
+	// 2024-04-04 JL: Added multiple picklists
+	// Check which team_key has been specified, if any, being one of the team_keys of the org
+	//- JL note: (maybe TODO between seasons): when picklist_key is undefined and team_keys.length > 1, it still loads orgteamvalues with picklist_key undefined, and loads data even though it wont' be displayed
+	let picklist_key: string|undefined = undefined;
+	if (typeof req.query.picklist_key === 'string') picklist_key = req.query.picklist_key;
+	if (picklist_key && !(req._user.org.team_keys?.includes(picklist_key))) throw new e.UserError(`Team key ${picklist_key} specified but it is not in your org's list of team_keys!`);
 
 	// 2019-03-21, M.O'C: Utilize the currentaggranges
 	// 2019-11-11 JL: Put everything inside a try/catch block with error conditionals throwing
 	try {
 		
 		// 2020-02-08, M.O'C: Change 'currentrankings' into event-specific 'rankings' 
-		//var rankings = await utilities.find("currentrankings", {}, {});
 		let rankings: Ranking[] = await utilities.find('rankings', {'event_key': event_key}, { sort: {'rank': 1} });
 		if(!rankings[0])
 			throw new e.InternalServerError('Couldn\'t find rankings in allianceselection');
@@ -453,7 +478,7 @@ router.get('/allianceselection', wrap(async (req, res) => {
 		// numAlliances is ~usually~ 8, but in some cases - e.g. 2022bcvi - there are fewer
 		let alliances: TeamKey[][] = [];
 		for (let i = 0; i < numAlliances; i++) {
-			alliances[i] = new Array().fill(numRounds);
+			alliances[i] = [].fill(numRounds);
 			alliances[i][0] = rankings[i].team_key; // preload first team 
 		}
 		logger.debug(`alliances=${JSON.stringify(alliances)}`);
@@ -525,7 +550,6 @@ router.get('/allianceselection', wrap(async (req, res) => {
 				// 2022-03-13 JL: Unlike on other pages like allteammetrics, the main focus of these data are the averages (instead of being switchable). 
 				//	Therefore, keeping the avg as .id and adding MAX as an "option" (to be displayed small on the table)
 				// 2022-03-28, M.O'C: Replacing flat $avg with the exponential moving average
-				//groupClause[thisLayout.id + 'AVG'] = {$avg: '$data.' + thisLayout.id}; 
 				groupClause[thisLayout.id + 'AVG'] = {$last: '$' + thisLayout.id + 'EMA'};
 				groupClause[thisLayout.id + 'MAX'] = {$max: '$data.' + thisLayout.id};
 			}
@@ -542,6 +566,7 @@ router.get('/allianceselection', wrap(async (req, res) => {
 					{$eq: ['$team_key', '$$team_key']},
 					{$eq: ['$org_key', org_key]},
 					{$eq: ['$event_key', event_key]},
+					{$eq: ['$picklist_key', picklist_key]}, // 2024-04-04 JL: added picklist_key
 				]}}},
 				{$project: {_id: 0, team_key: 0, event_key: 0, org_key: 0}}
 			],
@@ -614,7 +639,6 @@ router.get('/allianceselection', wrap(async (req, res) => {
 	
 		// read in the current agg ranges
 		// 2020-02-08, M.O'C: Tweaking agg ranges
-		// var currentAggRanges = await utilities.find("currentaggranges", {}, {});
 		let currentAggRanges: AggRange[] = await utilities.find('aggranges', {'org_key': org_key, 'event_key': event_key});
 	
 		//logger.debug('aggArray=' + JSON.stringify(aggArray));
@@ -625,11 +649,13 @@ router.get('/allianceselection', wrap(async (req, res) => {
 			numAlliances,
 			numRounds,
 			aggdata: aggArray,
-			currentAggRanges: currentAggRanges,
+			currentAggRanges,
 			layout: scoreLayout,
-			sortedTeams: sortedTeams,
-			matchcountConsistent: matchcountConsistent,
-			matchDataHelper: matchDataHelper
+			sortedTeams,
+			matchcountConsistent,
+			matchDataHelper,
+			picklist_key,
+			orgTeamKeys: req._user.org.team_keys,
 		});
 	}
 	catch (err) {

--- a/primary/views/dashboard/allianceselection.pug
+++ b/primary/views/dashboard/allianceselection.pug
@@ -38,104 +38,123 @@ block content
 			transition: 0s;
 		}
 	h2=title
-	div(class="w3-mobile w3-center")
-		p.i!=msg('allianceselection.intro')
-		p.i!=msgMarked('allianceselection.preferred')
-		if !matchcountConsistent
-			a(href="/manage/currentevent/matches") 
-				div(class="w3-btn theme-red") <b>WARNING: Rankings appear NOT to be up to date!</b><br/>Click here, update FIRST data before using for selection
-		div(class="w3-row w3-padding-small")
-			div(class="w3-left")
-				div(id="btnUndo" class="w3-btn theme-submit")!=msg('allianceselection.undo')
-			div(class="w3-right")
-				div(id="btnOptions" class="w3-btn theme-input")!=msg('allianceselection.options', undefined, '\xa0')
-		section(class="w3-row")
-			div(id="allianceSelection")
-				each alliance, i in alliances
-					- var allianceNum = i + 1;
-					div(class="w3-padding-small w3-col s12 m6 l3")
-						div(class="theme-dim w3-padding-large w3-col")
-							div(class="w3-col s0 m12")!=msg('allianceselection.allianceNumber', {number: allianceNum})
-							div(class="w3-col s2 m0") 
-								p(class="w3-large") #{allianceNum}
-							div(class="w3-col s10 m12")
-								div(class="w3-col s4 w3-padding-small")
-									div(id=alliance[0] alliance=allianceNum available="true" class="alliance-team w3-border w3-border-white")
-										span=alliance[0].substring(3)
-								- var teamIndex = 1 // starts at 2
-								while ++teamIndex <= numRounds
-									- team = alliance[teamIndex]
+	//- Dropdown to pick between team_keys at the org
+	if orgTeamKeys && orgTeamKeys.length > 1
+		form#teamKeyForm(class="w3-container w3-padding-16" method="get" action="/dashboard/allianceselection")
+			label(class="w3-label")
+				span(class="sprite sp-help sp-inline sp-16 w3-tooltip") &nbsp;
+					span(class="w3-tooltiptext")!=msg('allianceselection.tooltipPicklist')
+				span=msg('allianceselection.choosePicklist')
+			select(class="theme-input" name="picklist_key")
+				//- Show blank by default, require user to select their team from the dropdown
+				if !picklist_key
+					option(selected value="")
+				each thisTeamKey in orgTeamKeys
+					option(value=thisTeamKey selected=(picklist_key === thisTeamKey))=thisTeamKey.substring(3)
+		script.
+			$('select[name=picklist_key]').on('change', () => {
+				$('#teamKeyForm').trigger('submit');
+			});
+	//- Display the rest of the page only if picklist_key is specified OR if there's only 1 team on the org
+	if !orgTeamKeys || picklist_key
+		div(class="w3-mobile w3-center")
+			p.i!=msg('allianceselection.intro')
+			p.i!=msgMarked('allianceselection.preferred')
+			if !matchcountConsistent
+				a(href="/manage/currentevent/matches") 
+					div(class="w3-btn theme-red") <b>WARNING: Rankings appear NOT to be up to date!</b><br/>Click here, update FIRST data before using for selection
+			div(class="w3-row w3-padding-small")
+				div(class="w3-left")
+					div(id="btnUndo" class="w3-btn theme-submit")!=msg('allianceselection.undo')
+				div(class="w3-right")
+					div(id="btnOptions" class="w3-btn theme-input")!=msg('allianceselection.options', undefined, '\xa0')
+			section(class="w3-row")
+				div(id="allianceSelection")
+					each alliance, i in alliances
+						- var allianceNum = i + 1;
+						div(class="w3-padding-small w3-col s12 m6 l3")
+							div(class="theme-dim w3-padding-large w3-col")
+								div(class="w3-col s0 m12")!=msg('allianceselection.allianceNumber', {number: allianceNum})
+								div(class="w3-col s2 m0") 
+									p(class="w3-large") #{allianceNum}
+								div(class="w3-col s10 m12")
 									div(class="w3-col s4 w3-padding-small")
-										div(id=`all${allianceNum}team${teamIndex}` alliance=allianceNum class="alliance-team w3-border w3-border-white")
-											span=(team) ? team.substring(3) : `[${teamIndex}]`
-				hr(class="w3-col")
-				div(class="w3-col")
-					each team, i in sortedTeams
-						div(class="w3-col s4 m2 l1 w3-padding-small")
-							div(id=team.team_key available="true" class="theme-dim alliance-team w3-border w3-border-white")
-								span=team.team_key.substring(3)
+										div(id=alliance[0] alliance=allianceNum available="true" class="alliance-team w3-border w3-border-white")
+											span=alliance[0].substring(3)
+									- var teamIndex = 1 // starts at 2
+									while ++teamIndex <= numRounds
+										- team = alliance[teamIndex]
+										div(class="w3-col s4 w3-padding-small")
+											div(id=`all${allianceNum}team${teamIndex}` alliance=allianceNum class="alliance-team w3-border w3-border-white")
+												span=(team) ? team.substring(3) : `[${teamIndex}]`
+					hr(class="w3-col")
+					div(class="w3-col")
+						each team, i in sortedTeams
+							div(class="w3-col s4 m2 l1 w3-padding-small")
+								div(id=team.team_key available="true" class="theme-dim alliance-team w3-border w3-border-white")
+									span=team.team_key.substring(3)
+			hr
+			
+			div(class="w3-section")
+				input(class="w3-check w3-margin-right" type="checkbox" checked id="showHideData")
+				label(for="showHideData")!=msg('allianceselection.showData')
+			div#data()
+				include allianceselection-info
+
 		hr
-		
-		div(class="w3-section")
-			input(class="w3-check w3-margin-right" type="checkbox" checked id="showHideData")
-			label(for="showHideData")!=msg('allianceselection.showData')
-		div#data()
-			include allianceselection-info
+		div(id="options")
+			div(class="w3-margin-top w3-show-inline-block w3-mobile")
+				label(class="w3-label" style="padding-right: 8px")!=msg('allianceselection.numAlliances')
+				select(class="theme-input" style="min-width: 100;" name="numAlliances" id="numAlliances")
+					- var n = 1; // starts at 2
+					while ++n <= 8
+						option(selected=(n == numAlliances) value=n)=n
+			span(class="w3-hide-small") &nbsp;
+			div(class="w3-margin-top w3-show-inline-block w3-mobile")
+				label(class="w3-label" style="padding-right: 8px")!=msg('allianceselection.numRounds')
+				select(class="theme-input" style="min-width: 100;" name="numRounds" id="numRounds")
+					- var n = 1; // starts at 2
+					while ++n <= 4
+						option(selected=(n == numRounds) value=n)=n
 
-	hr
-	div(id="options")
-		div(class="w3-margin-top w3-show-inline-block w3-mobile")
-			label(class="w3-label" style="padding-right: 8px")!=msg('allianceselection.numAlliances')
-			select(class="theme-input" style="min-width: 100;" name="numAlliances" id="numAlliances")
-				- var n = 1; // starts at 2
-				while ++n <= 8
-					option(selected=(n == numAlliances) value=n)=n
-		span(class="w3-hide-small") &nbsp;
-		div(class="w3-margin-top w3-show-inline-block w3-mobile")
-			label(class="w3-label" style="padding-right: 8px")!=msg('allianceselection.numRounds')
-			select(class="theme-input" style="min-width: 100;" name="numRounds" id="numRounds")
-				- var n = 1; // starts at 2
-				while ++n <= 4
-					option(selected=(n == numRounds) value=n)=n
-
-	script.
-		//create selection state
-		window.state = {};
-		numAlliances = parseInt(#{numAlliances});
-		console.log(`numAlliances=${numAlliances}`);
-		numRounds = parseInt(#{numRounds});
-		//CURRENTLY UNUSED
-		//state.alliances = [["#{alliances[0][0]}""]];
-		//Starting alliance 1 captain, before any user input
-		window.startingCaptain = "#{alliances[0][0]}";
+		script.
+			//create selection state
+			window.state = {};
+			numAlliances = parseInt(#{numAlliances});
+			console.log(`numAlliances=${numAlliances}`);
+			numRounds = parseInt(#{numRounds});
+			//CURRENTLY UNUSED
+			//state.alliances = [["#{alliances[0][0]}""]];
+			//Starting alliance 1 captain, before any user input
+			window.startingCaptain = "#{alliances[0][0]}";
+			
+			state.rankings = [null];
+			//currently selected team
+			state.currentSelectedTeam = null;
+			//history of selected teams
+			/*
+				[
+					{
+						"teamKey": "frc102",
+						"previousSpot": rank before selected,
+						"allianceSpot": 2 or 3
+					}
+				]
+			*/
+			state.moveHistory = [];
+			//round 0 goes from alliance 1 to 8; round 1 goes from alliance 8 to 1
+			state.currentRound = 0;
+			//current alliance that is choosing a team
+			state.currentAlliance = 1;
+			//Previous states of allianceSelection
+			var previousStates = [];
 		
-		state.rankings = [null];
-		//currently selected team
-		state.currentSelectedTeam = null;
-		//history of selected teams
-		/*
-			[
-				{
-					"teamKey": "frc102",
-					"previousSpot": rank before selected,
-					"allianceSpot": 2 or 3
-				}
-			]
-		*/
-		state.moveHistory = [];
-		//round 0 goes from alliance 1 to 8; round 1 goes from alliance 8 to 1
-		state.currentRound = 0;
-		//current alliance that is choosing a team
-		state.currentAlliance = 1;
-		//Previous states of allianceSelection
-		var previousStates = [];
-	
-		// i18n messages used by client script
-		window.i18n = {};
-	| <script>
-	each team, i in rankings
-		| state.rankings[#{i+1}] = "#{team.team_key}";
-	each msg in ['wontSave', 'noPreviousState', 'noLastMove', 'noAllianceAttribute', 'noTeamStateRankings']
-		| i18n["#{msg}"] = !{msgJs('allianceselection.' + msg)};
-	| </script>
-	script(src=`${fileRoot}/js/script-allianceselection.js?v`)
+			// i18n messages used by client script
+			window.i18n = {};
+		| <script>
+		each team, i in rankings
+			| state.rankings[#{i+1}] = "#{team.team_key}";
+		each msg in ['wontSave', 'noPreviousState', 'noLastMove', 'noAllianceAttribute', 'noTeamStateRankings']
+			| i18n["#{msg}"] = !{msgJs('allianceselection.' + msg)};
+		| </script>
+		script(src=`${fileRoot}/js/script-allianceselection.js?v${functionVersion}`)

--- a/primary/views/dashboard/driveteam.pug
+++ b/primary/views/dashboard/driveteam.pug
@@ -46,16 +46,16 @@ block content
 				span(class="w3-mobile w3-margin-top")
 					label(class="w3-label" style="padding-right: 8px")!=msg('driveDashboard.viewFor')
 					select(class="theme-input" style="min-width: 100;" name="team_key")
-						noscript
-							if selectedTeam == 'all'
-								option(selected value='all')!=msg('driveDashboard.chooseTeam')
-							//- else
-								option(value='all') All teams
+						if selectedTeam == 'all'
+							option(selected value='all')!=msg('driveDashboard.chooseTeam')
+						//- List of team keys in this org
+						if orgTeamKeys.length > 0
+							each team_key in orgTeamKeys
+								option(value=team_key selected=(team_key === selectedTeam))=team_key.substring(3)	
+							option ----- !{msg('driveDashboard.otherTeams')} -----
 						each team in teams 
-							if team.key == selectedTeam
-								option(selected value=team.key)=team.team_number
-							else 
-								option(value=team.key)=team.team_number
+							if !orgTeamKeys.includes(team.key)
+								option(selected=(team.key === selectedTeam) value=team.key)=team.team_number
 					noscript
 						//- JL: I made the multiselect auto-submit on change, but to make it still work in browsers with JS disabled, this submit button will act in its place.
 						button(class="w3-btn theme-submit w3-margin-left" type="submit" name="selected" value="true")!=msg('driveDashboard.selectedTeam')

--- a/primary/views/manage/allianceselection.pug
+++ b/primary/views/manage/allianceselection.pug
@@ -13,55 +13,71 @@ block content
 		}
 	include ../reports/templates/heatmap
 	h2 Alliance Selection Data
-	p.i.
-		The two buttons on the left can keep track of preferred (and otherwise) teams for Alliance Selection.
-		<br>Numbers under the "V" are visible and sortable by your scouting lead on the <a class="link" href="/dashboard/allianceselection" target="_blank">Alliance Selection dashboard</a>.
-	p.i Don't pull your punches! Only people who have logged in to your organization can see these numbers.
-	p.i=msg('allianceselection.tapForPopup')
-	if (aggdata)
-		- var aggRangeMap = [];
-		for scoreItem in currentAggRanges
-			- aggRangeMap[scoreItem.key] = scoreItem;
-		table(class="w3-table" id="metricTable")
-			tr
-				th(colspan=2 no-sort) Priority
-				th(class="w3-center") V
-				th(class="w3-center") Team
-				th(class="w3-center") Rank
-				- var colIdx = 4;
-				for item in layout
-					-//if (item.type == 'checkbox' || item.type == 'counter' || item.type == 'badcounter')
-					if (matchDataHelper.isQuantifiableType(item.type))
-						- var text = item.key; var result1 = text.replace( /([A-Z])/g, " $1" ); var result2 = result1.charAt(0).toUpperCase() + result1.slice(1)
-						th(class="w3-right-align")= result2
-						- colIdx++
-			for row in aggdata
+	//- Dropdown to pick between team_keys at the org
+	if orgTeamKeys && orgTeamKeys.length > 1
+		form#teamKeyForm(class="w3-container w3-padding-16" method="get" action="/manage/allianceselection")
+			label(class="w3-label")
+				span(class="sprite sp-help sp-inline sp-16 w3-tooltip") &nbsp;
+					span(class="w3-tooltiptext")!=msg('allianceselection.tooltipPicklist')
+				span=msg('allianceselection.choosePicklist')
+			select(class="theme-input" name="picklist_key")
+				//- Show blank by default, require user to select their team from the dropdown
+				if !picklist_key
+					option(selected value="")
+				each thisTeamKey in orgTeamKeys
+					option(value=thisTeamKey selected=(picklist_key === thisTeamKey))=thisTeamKey.substring(3)
+	//- Display the rest of the page only if picklist_key is specified OR if there's only 1 team on the org
+	if !orgTeamKeys || picklist_key
+		p.i.
+			The two buttons on the left can keep track of preferred (and otherwise) teams for Alliance Selection.
+			<br>Numbers under the "V" are visible and sortable by your scouting lead on the <a class="link" href="/dashboard/allianceselection" target="_blank">Alliance Selection dashboard</a>.
+		p.i Don't pull your punches! Only people who have logged in to your organization can see these numbers.
+		p.i=msg('allianceselection.tapForPopup')
+		if (aggdata)
+			- var aggRangeMap = [];
+			for scoreItem in currentAggRanges
+				- aggRangeMap[scoreItem.key] = scoreItem;
+			table(class="w3-table" id="metricTable")
 				tr
-					td(style="padding: 2px!important;")
-						button(class="w3-button theme-red scouting-counter sc-small" onclick=`setValue('${row._id}', -1)` type="button") -
-					td(style="padding: 2px!important;")
-						button(class="w3-button w3-hover-green theme-submit scouting-counter sc-small" onclick=`setValue('${row._id}', 1)` type="button") +
-					td(class="w3-center" team-value key=row._id)= row.value
-					//- Change the team number's class depending on the row value
-					td(class="w3-center underline clickable" team-number key=row._id class=(row.value > 0 ? 'wanted-team' : row.value < 0 ? 'unwanted-team' : ''))= row._id.substring(3)
-					td(class="w3-right-align")= row.rank
+					th(colspan=2 no-sort) Priority
+					th(class="w3-center") V
+					th(class="w3-center") Team
+					th(class="w3-center") Rank
+					- var colIdx = 4;
 					for item in layout
 						-//if (item.type == 'checkbox' || item.type == 'counter' || item.type == 'badcounter')
 						if (matchDataHelper.isQuantifiableType(item.type))
-							- var valStyle = 'w3-right-align w3-text-white'
-							- if (row[item.key] == 0) valStyle = 'w3-right-align w3-text-gray'
-							if (aggRangeMap[item.key])
-								td(class=`${valStyle}` style=`background-color: rgb(${getValR(aggRangeMap[item.key].AVGmin, aggRangeMap[item.key].AVGmax, row[item.key])},${getValG(aggRangeMap[item.key].AVGmin, aggRangeMap[item.key].AVGmax, row[item.key])},${getValB(aggRangeMap[item.key].AVGmin, aggRangeMap[item.key].AVGmax, row[item.key])})`)= row[item.key]
-							else
-								td(class=`${valStyle}`)= row[item.key]
-	else
-		p.i Insufficient data at this time, come back later!
+							- var text = item.key; var result1 = text.replace( /([A-Z])/g, " $1" ); var result2 = result1.charAt(0).toUpperCase() + result1.slice(1)
+							th(class="w3-right-align")= result2
+							- colIdx++
+				for row in aggdata
+					tr
+						td(style="padding: 2px!important;")
+							button(class="w3-button theme-red scouting-counter sc-small" onclick=`setValue('${row._id}', -1, "${picklist_key}")` type="button") -
+						td(style="padding: 2px!important;")
+							button(class="w3-button w3-hover-green theme-submit scouting-counter sc-small" onclick=`setValue('${row._id}', 1, "${picklist_key}")` type="button") +
+						td(class="w3-center" team-value key=row._id)= row.value
+						//- Change the team number's class depending on the row value
+						td(class="w3-center underline clickable" team-number key=row._id class=(row.value > 0 ? 'wanted-team' : row.value < 0 ? 'unwanted-team' : ''))= row._id.substring(3)
+						td(class="w3-right-align")= row.rank
+						for item in layout
+							-//if (item.type == 'checkbox' || item.type == 'counter' || item.type == 'badcounter')
+							if (matchDataHelper.isQuantifiableType(item.type))
+								- var valStyle = 'w3-right-align w3-text-white'
+								- if (row[item.key] == 0) valStyle = 'w3-right-align w3-text-gray'
+								if (aggRangeMap[item.key])
+									td(class=`${valStyle}` style=`background-color: rgb(${getValR(aggRangeMap[item.key].AVGmin, aggRangeMap[item.key].AVGmax, row[item.key])},${getValG(aggRangeMap[item.key].AVGmin, aggRangeMap[item.key].AVGmax, row[item.key])},${getValB(aggRangeMap[item.key].AVGmin, aggRangeMap[item.key].AVGmax, row[item.key])})`)= row[item.key]
+								else
+									td(class=`${valStyle}`)= row[item.key]
+		else
+			p.i Insufficient data at this time, come back later!
 	script.
-		function setValue(teamKey, value)
+		function setValue(teamKey, value, picklist_key)
 		{
-			console.log("teamKey " + teamKey + ", value " + value);
+			console.log(`teamKey=${teamKey}, value=${value}, picklist_key=${picklist_key}`);
+			if (picklist_key === 'undefined') picklist_key = undefined;
 			
-			$.post('/manage/allianceselection/updateteamvalue', {key: teamKey, value: value})
+			$.post('/manage/allianceselection/updateteamvalue', {key: teamKey, value, picklist_key})
 				.done(msg => {
 					//- Update the row with the team's new value
 					var newValue = msg.value;
@@ -84,6 +100,9 @@ block content
 			$('td[team-number]').on('click', function () {
 				let team_key = $(this).attr('key');
 				Dialog.showURL(`/reports/teamintel?team_key=${team_key}`);
+			})
+			$('select[name=picklist_key]').on('change', () => {
+				$('#teamKeyForm').trigger('submit');
 			})
 		})
 	//- the "Priority" header takes up 2 columns so offset row by an extra 1

--- a/primary/views/manage/config/index.pug
+++ b/primary/views/manage/config/index.pug
@@ -47,16 +47,22 @@ block content
 							option(value="1") true
 	div(class="w3-auto w3-content")
 		h2=title
-		form(id=`updateOrg_${org.org_key}` method="post" action="/manage/config")
+		form(id="updateOrg" method="post" action="/manage/config")
 			div(class="w3-row")
 				//- Top row
-				div(class="w3-col s0 m2 w3-padding-small") ID
-				div(class="w3-col s0 m8 w3-padding-small") Nickname
+				div(class="w3-col s6 m2 w3-padding-small") ID
+				div(class="w3-col s6 m4 w3-padding-small") 
+					span Team(s)&nbsp;
+					span(class="w3-tooltip sprite sp-help sp-16") &nbsp;
+						span(class="w3-tooltiptext")=msg('manage.config.tooltipTeams')
+				div(class="w3-col s6 m4 w3-padding-small") Nickname
 				div(class="w3-col s0 m2 w3-padding-small") &nbsp;
 				div(class="w3-col s6 m2 w3-padding-small")
 					input(disabled type="text" class="theme-input w3-disabled" value=org.org_key)
 					input(type="hidden" name="org_key" value=org.org_key)
-				div(class="w3-col s6 m8 w3-padding-small")
+				div(class="w3-col s6 m4 w3-padding-small")
+					input(type="text" class="theme-input" name="team_numbers" value=team_numbers.join(', '))
+				div(class="w3-col s6 m4 w3-padding-small")
 					input(type="text" class="theme-input" name="nickname" value=org.nickname)
 				div(class="w3-col m2 w3-padding-small")
 					button(type="submit" class="w3-btn theme-submit") Update Org
@@ -67,7 +73,7 @@ block content
 					div(class="w3-col s4") 
 						span Key&nbsp;
 						span(class="w3-tooltip sprite sp-help sp-16") &nbsp;
-							span(class="w3-tooltiptext") Write a unique identifier for each subteam. After you create a subteam, the label can change but the key should not change.
+							span(class="w3-tooltiptext")=msg('manage.config.tooltipSubteamKey')
 					div(class="w3-col s4") Pit scout?
 					div(id=`subteams_${org.org_key}`)
 						each subteam, i in org.config.members.subteams 
@@ -82,7 +88,7 @@ block content
 					div(class="w3-col s3") 
 						span Key&nbsp;
 						span(class="w3-tooltip sprite sp-help sp-16") &nbsp;
-							span(class="w3-tooltiptext") Write a unique identifier for each class. After you create a class, the label can change but the key should not change.
+							span(class="w3-tooltiptext")=msg('manage.config.tooltipClassKey')
 					div(class="w3-col s3") Seniority
 					div(class="w3-col s3") Youth?
 					div(id=`classes_${org.org_key}`)
@@ -108,3 +114,18 @@ block content
 			+classname('num', {label: '', key: '', seniority: '', youth: true})
 	//- Load orgs script
 	script(src=`${fileRoot}/js/script-orgs.js`)
+	script.
+		$('#updateOrg').on('submit', function(e) {
+			e.preventDefault();
+			let data = FormSubmission.getFormData(this);
+			$.post('/manage/config', data)
+				.done(response => {
+					console.log(response);
+					NotificationCard.good(response);
+				})
+				.fail(response => {
+					console.error(response);
+					NotificationCard.error(response.responseText)
+				})
+			return false;
+		})

--- a/scoutradioz-types/types.d.ts
+++ b/scoutradioz-types/types.d.ts
@@ -311,6 +311,7 @@ export declare interface OrgClass {
 export declare interface OrgTeamValue extends DbDocument {
 	org_key: OrgKey;
 	team_key: TeamKey;
+	picklist_key: string|undefined;
 	event_key: EventKey;
 	value: number;
 }


### PR DESCRIPTION
Fixes #235

- Added ability for org managers to edit the list of team keys in the org
- For orgs with multiple teams, each team gets their own picklist
- Added the list of teams to the top of the drive team dashboard, and the chosen team gets saved in a cookie BUT ONLY FOR DT DASHBOARD AND NOT FOR ALLIANCESLECTION. This is intentional, as it is important for the person loading/editing their picklist to NOT accidentally edit/view the wrong picklist (e.g., say they previously opened the DT dashboard for another team just out of curiosity, then later open the alliance selection data page, not realizing they are now viewing the picklist for another team. Don't want that to happen.)

KNOWN QUIRKS:
- It gets weird if you switch between having 1 or no teams listed in the org, and multiple teams in the org, after editing the picklist.
- If you have multiple teams in your org, and then browse a past event during which you only had 1 or 0 teams in your org, you can't view the picklist.

Can't bypass these quirks without doing a database update and forcing the `picklist_key` to be non-undefined in the code, which is absolutely out of the question for me to do in the middle of competitions.