### PR TITLE
Adjusted query for completed matches, also tweaked verbiage for 'browse' page

### DIFF
--- a/primary/locales/en.json
+++ b/primary/locales/en.json
@@ -5,11 +5,11 @@
 		"browse": {
 			"link": "Or click here to browse data by event",
 			"title": "View data by event and org",
-			"tspsExplained": "'TSPS' is **relative** Total Scouting Performance Score (useful for friendly inter-org Scouting competitions!)",
+			"tspsExplained": "'TSPS' is **relative** Total Scouting Performance Score (useful for friendly inter-org Scouting competitions!) - and 'Mdn.' is short for Median",
 			"pastEvents": "To see older data you may need to use the menu option under Info and Reports, 'Browse data from past events'",
 			"orgKeyAndNickname": "Org key - Nickname",
 			"matchScoutingEntries": "# Match scouting entries",
-			"avgErrorRate": "Avg. error rate (and minimum)",
+			"avgErrorRate": "Mdn. error rate (and minimum)",
 			"tspsScore": "TSPS"
 		},
 		"choice": "Are you:",

--- a/primary/src/routes/index.ts
+++ b/primary/src/routes/index.ts
@@ -222,7 +222,7 @@ router.get('/browse', wrap(async (req, res, next) => {
 
 		// get the matches for this event
 		let matches: Match[] = await utilities.find('matches',
-			{ 'event_key': thisEventKey, 'comp_level': 'qm', 'score_breakdown': { '$ne': undefined } }, { sort: { match_number: 1 } },
+			{ 'event_key': thisEventKey, 'comp_level': 'qm', 'score_breakdown': { '$ne': undefined }, 'alliances.red.score': {$ne: -1} }, { sort: { match_number: 1 } },
 			{allowCache: true, maxCacheAge: 300}
 		);
 		let matchDict: { [id: string]: Match } = {};


### PR DESCRIPTION
Browse page, when calculating "completion percentage" component, was not excluding records in 'matches' where there was a record _but_ the alliance scores were "-1".

Also changed the abbr. for "Average" (for the SPR score) to the abbr. for "Median" 