### PR TITLE
Auto disable dynamic scrolling

### DIFF
--- a/primary/public-src/less/scouting.less
+++ b/primary/public-src/less/scouting.less
@@ -87,7 +87,11 @@
 	right: 0;
 	z-index: 1;
 }
+// Using a CSS variable so it can be disabled in JS
+:root {
+	--disabled-form-filter: blur(2px);
+}
 .disabled-form{
 	opacity: 0.7;
-	filter: blur(2px);
+	filter: var(--disabled-form-filter);
 }

--- a/primary/public-src/ts-bundled/scoutradioz.ts
+++ b/primary/public-src/ts-bundled/scoutradioz.ts
@@ -29,7 +29,7 @@ $(() => {
 });
 
 
-declare function debugToHTML(message: any): void;
+declare function debugToHTML(message: any, replace?: boolean): void;
 /**
  * Run a particular piece of code when the window resizes, but after waiting a few ms to reduce processor demand.
  * @param cb Callback to run on a resize event.
@@ -74,7 +74,7 @@ declare function onResize(cb: () => void): void;
 		'padding': '8px 16px',
 	});
 	
-	window.debugToHTML = function(message: string) {
+	window.debugToHTML = function(message: string, replace?: boolean) {
 		
 		let text;
 		
@@ -99,6 +99,7 @@ declare function onResize(cb: () => void): void;
 		let newTextElem = document.createElement('pre');
 		$(newTextElem).text(text).css({'margin': '0.5em 0px'});
 		
+		if (replace === true) $(debugLogger).html('');
 		$(debugLogger).append(newTextElem);
 	};
 })();

--- a/primary/public-src/ts/bundle.d.ts
+++ b/primary/public-src/ts/bundle.d.ts
@@ -280,7 +280,7 @@ interface ConfirmOptions {
     noText?: string;
     yesTimeout?: number;
 }
-declare function debugToHTML(message: any): void;
+declare function debugToHTML(message: any, replace?: boolean): void;
 /**
  * Run a particular piece of code when the window resizes, but after waiting a few ms to reduce processor demand.
  * @param cb Callback to run on a resize event.

--- a/primary/public-src/ts/script-matchscouting.ts
+++ b/primary/public-src/ts/script-matchscouting.ts
@@ -14,6 +14,12 @@ let sections = [] as Array<{
 }>;
 
 $(function () {
+	// disable blur when the page loads if it's been disabled before in this session
+	if (sessionStorage.blurDisabled) {
+		console.log('Disabling blur due to session variable');
+		disableBlur();
+	}
+
 	$('#toggleStickyToggle').addClass('animate');
 
 	$('#toggleSticky').on('change', () => {
@@ -111,6 +117,13 @@ $(function () {
 		
 		setSection(closestSection);
 	}
+	
+	// For older devices that don't have the performance to handle blur
+	function disableBlur() {
+		$(':root').css({
+			'--disabled-form-filter': 'none'
+		});
+	}
 
 	function setSection(idx: number) {
 		assert(sections[idx], new RangeError());
@@ -130,7 +143,18 @@ $(function () {
 			}
 		}
 		stickyBarTitle.text(sections[idx].label);
-		console.log(performance.now() - st);
+		// Check the time it takes to do the layout recalc
+		if (!sessionStorage.blurDisabled) {
+			let t2 = performance.now();
+			document.body.offsetWidth;
+			let t3 = performance.now();
+			// if it takes a long time to do the recalc, disable blur
+			if (t3 - t2 > 50) {
+				console.log('Disabling blur');
+				disableBlur();
+				sessionStorage.blurDisabled = '1';
+			}
+		}
 	}
 
 	stickyBarLeft.on('click', () => {

--- a/primary/views/index.pug
+++ b/primary/views/index.pug
@@ -74,7 +74,7 @@ block content
 						span(class="sprite sp-22 sp-black sp-info sp-inline")
 						span!=msg('index.info.wiki')
 				div.w3-center.w3-margin-top(id="discordLink")
-					a(class="theme-link w3-btn gear-btn" href="https://discord.gg/Mr3kyqkSrQ" target="_blank")
+					a(class="theme-link w3-btn gear-btn" href="https://discord.gg/hUsbWTeEVz" target="_blank")
 						span(class="sprite sp-22 sp-black sp-discord sp-inline")
 						span!=msg('index.info.discord')
 				div.w3-center.w3-margin-top


### PR DESCRIPTION
The dynamic scrolling feature is pretty bad on old/slow devices. This feature attempts to detect when the blur effect takes a long time to render, which is an indication of a device that's pretty slow, and then it disables dynamic scrolling for the remainder of the session.