### PR TITLE
Round numeric values in teammatchintel to two decimal places

### DIFF
--- a/primary/views/reports/teammatchintel.pug
+++ b/primary/views/reports/teammatchintel.pug
@@ -29,7 +29,7 @@ block content
 						br
 					//- 2023-03-19 JL: Switched hardcoded counter/badcounter/derived/etc. to "default" to allow for new numerical types to be displayed
 					default
-						h4(class="theme-text") #{element.label}#{element.label.endsWith(':')?'':':'} <strong>#{data[element.id]}</strong>
+						h4(class="theme-text") #{element.label}#{element.label.endsWith(':')?'':':'} <strong>#{typeof data[element.id] === "number" ? data[element.id].toFixed(2).replace(/\.?0*$/,'') : data[element.id]}</strong>
 		else
 			+noDataFound(msg('reports.noMatchScoutData', {team: teamKey.substring(3), match: teammatch.match_number}))
 	else


### PR DESCRIPTION
In `/reports/teammatchintel`, round numeric values to two decimal places. Closes #215.
Before:
![image](https://github.com/user-attachments/assets/f99d82ac-b699-4e42-b60a-f1b1552e758c)
After: 
![image](https://github.com/user-attachments/assets/b5fe6076-328e-46d5-ad17-b558e919b9be)
