### PR TITLE
Allow h2/h3 to have no id specified in form

### DIFF
--- a/primary/public-src/ts/script-editform.ts
+++ b/primary/public-src/ts/script-editform.ts
@@ -49,7 +49,7 @@ async function validate() {
 				let thisLabel = jsonData[i]['label'];
 				if (!thisLabel) {
 					console.log(`${thisType} missing both id and label:`, jsonData[i]);
-					NotificationCard.error('h2 or h3 need either \'id\' or \'label\' attribute! Please correct.');
+					NotificationCard.error('Missing at least one \'label\' attribute on h2/h3! Please correct.');
 					return null;
 				}
 				thisId = thisType + '_' + thisLabel.replace(/\s+/g, '_');

--- a/primary/public-src/ts/script-editform.ts
+++ b/primary/public-src/ts/script-editform.ts
@@ -45,6 +45,16 @@ async function validate() {
 
 		if (thisType != 'spacer') {
 			let thisId = jsonData[i]['id'];
+			if (!thisId && (thisType == 'h3' || thisType == 'h2')) {
+				let thisLabel = jsonData[i]['label'];
+				if (!thisLabel) {
+					console.log(`${thisType} missing both id and label:`, jsonData[i]);
+					NotificationCard.error('h2 or h3 need either \'id\' or \'label\' attribute! Please correct.');
+					return null;
+				}
+				thisId = thisType + '_' + thisLabel.replace(/\s+/g, '_');
+				jsonData[i]['id'] = thisId;
+			}
 			// 2024-01-26 JL: changed `== null` comparison to truthiness check, because I think empty strings should not be a valid id ('' is falsy)
 			if (!thisId) {
 				console.log('Missing id:', jsonData[i]);

--- a/primary/views/scouting/templates/formSubHeader.pug
+++ b/primary/views/scouting/templates/formSubHeader.pug
@@ -1,1 +1,1 @@
-h3(class="theme-text w3-padding-16 theme-subheader")=element.label
+h3(class="theme-text w3-padding-16 theme-subheader" id=element.id)=element.label


### PR DESCRIPTION
According to the wiki:

> h2: This is a header element. It DOES NOT require an `id` but DOES require a `label` attribute, containing the text to display.

It says the same thing for h3. However, previously attempting to have one of these without an `id` would error. This would generate an `id` composed of the type of element (just h2/h3), an underscore, and the label with whitespace replaced with underscores. Additionally, when doing this I found that when rendering a scouting form, the system would not give `h3` elements their id stored in the database. This is now fixed.

Closes #259.