### PR TITLE
Make test-form modal dialogs not show header

### DIFF
--- a/primary/public-src/ts/script-editform.ts
+++ b/primary/public-src/ts/script-editform.ts
@@ -203,6 +203,7 @@ async function test() {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
+			'in-modal-dialog': 'true',
 		},
 		body: JSON.stringify({
 			testData: jsonString,

--- a/primary/views/scouting/match.pug
+++ b/primary/views/scouting/match.pug
@@ -70,26 +70,28 @@ block content
 						when "spacer"
 							include templates/formSpacer
 	br 
-	button#submit( onclick="window.onbeforeunload = null;" class="w3-btn theme-submit")!=msg('scouting.submit')
-	if user && user.role.access_level >= Permissions.ACCESS_TEAM_ADMIN
-		hr 
-		p!=msg('scouting.orgManagerActions')
-		div(class="w3-btn theme-submit theme-red" id="btnClearData")!=msg('scouting.clearData')
-		script.
-			$('#btnClearData').on('click', async () => {
-				let result = await PasswordPrompt.show(!{msgJs('scouting.clearDataConfirm')});
-				if (result.cancelled == false) {
-					$.post('/scouting/match/delete-data', {password: result.password, match_team_key: '#{key}'})
-						.done(result => {
-							if (result.success) {
-								NotificationCard.good(result.message);
-							}
-							else {
-								NotificationCard.error(result.message);
-							}
-						});
-				}
-			});
+	//- 2024-10-19 JL: Hide submit button if created from the test form button
+	if !inModalDialog
+		button#submit( onclick="window.onbeforeunload = null;" class="w3-btn theme-submit")!=msg('scouting.submit')
+		if user && user.role.access_level >= Permissions.ACCESS_TEAM_ADMIN
+			hr
+			p!=msg('scouting.orgManagerActions')
+			div(class="w3-btn theme-submit theme-red" id="btnClearData")!=msg('scouting.clearData')
+			script.
+				$('#btnClearData').on('click', async () => {
+					let result = await PasswordPrompt.show(!{msgJs('scouting.clearDataConfirm')});
+					if (result.cancelled == false) {
+						$.post('/scouting/match/delete-data', {password: result.password, match_team_key: '#{key}'})
+							.done(result => {
+								if (result.success) {
+									NotificationCard.good(result.message);
+								}
+								else {
+									NotificationCard.error(result.message);
+								}
+							});
+					}
+				});
 	br 
 	br 
 	each element in layout

--- a/primary/views/scouting/pit.pug
+++ b/primary/views/scouting/pit.pug
@@ -101,8 +101,10 @@ block content
 						when "spacer"
 							include templates/formSpacer
 		br 
-		button#submit( onclick="window.onbeforeunload = null;" class="w3-btn theme-submit")!=msg('scouting.submit')
-		p 
+		//- 2024-10-19 JL: Hide submit button if created from the test form button
+		if !inModalDialog
+			button#submit( onclick="window.onbeforeunload = null;" class="w3-btn theme-submit")!=msg('scouting.submit')
+			p
 	each element in layout
 		case element.type
 			when "checkbox"


### PR DESCRIPTION
The header can still appear if you go into dashboard -> alliance selection, click on a team, then click on one of the links e.g. upcoming matches, but I think that that bug is obscure enough to not be worth wasting time fixing.