### PR TITLE
Gave a message for a derived recalculation

### DIFF
--- a/primary/locales/en.json
+++ b/primary/locales/en.json
@@ -460,6 +460,7 @@
 			"matches": "Matches (FIRST data)",
 			"noEvent": "No event has been set",
 			"recalcDerived": "Recalculate derived metrics",
+			"recalcDerivedSuccess": "Derived metrics succesfully recalculated!",
 			"setCurrentEvent": "Set current event",
 			"setCurrentEventKey": "Set current event key",
 			"successClear": "Cleared current event successfully.",

--- a/primary/src/routes/admin/sync.ts
+++ b/primary/src/routes/admin/sync.ts
@@ -328,7 +328,7 @@ router.get('/recalcderived', wrap(async (req, res) => {
 	
 	// 2022-03-04 JL: fixed bug & put the update stuff into a bulkWrite
 	let writeResult = await utilities.bulkWrite('matchscouting', writeQueries);
-	res.send(`SUCCESS - done in ${Date.now() - startTime} ms - writeResult = ${JSON.stringify(writeResult)}`);
+	// res.send(`SUCCESS - done in ${Date.now() - startTime} ms - writeResult = ${JSON.stringify(writeResult)}`);
 	
 	// 2023-03-19 JL: Recalculate agg ranges when recalculating derived
 	matchDataHelper.calculateAndStoreAggRanges(org_key, event_year, event_key);
@@ -341,6 +341,10 @@ router.get('/recalcderived', wrap(async (req, res) => {
 	
 	//2020-03-27 (security hole) removed res.render(admin) and switched with res.send
 	// res.send('SUCCESS');
+	res.render('./message',{
+		title: res.msg('manage.event.recalcDerived'),
+		message: res.msg('manage.event.recalcDerivedSuccess'),
+	});
 }));
 
 


### PR DESCRIPTION
Sent a simple message saying "Derived metrics succesfully recalculated!' when clicking derived metrics in scoutradioz.