### PR TITLE
Add support for news-update messages and site-wide maintenance mode

### DIFF
--- a/primary/public-src/ts-bundled/NotificationCard.ts
+++ b/primary/public-src/ts-bundled/NotificationCard.ts
@@ -41,7 +41,7 @@ class NotificationCard{
 	 * @param {boolean} [options.exitable=false] Whether card has an exit button.
 	 * @param {function} [options.onexit=undefined] Callback for when a user clicks the exit button.
 	 */
-	constructor(text: string, options?: object){
+	constructor(text: string, options?: NotificationCardOptions){
 		
 		if (!options) options = {};
 		
@@ -234,41 +234,51 @@ class NotificationCard{
 		return this;
 	}
 	
-	_filterOptions(options: any){
+	_filterOptions(options: NotificationCardOptions){
 		
 		let defaultOpts = new NotificationCardOptions();
 		
-		let opts = defaultOpts;
-		
-		for (let option in opts) {
-			
-			if (options.hasOwnProperty(option)) {	
-				switch(option){
-					case 'type':
-						if (typeof options[option] == 'string') opts[option] = options[option];
-						else throw new TypeError('NotificationCard.opts.type must be string.');
-						break;
-					case 'ttl':
-						if (typeof options[option] == 'number') opts[option] = options[option];
-						else throw new TypeError('NotificationCard.opts.ttl must be a number.');
-						break;
-					case 'exitable':
-						if (typeof options[option] == 'boolean') opts[option] = options[option];
-						else throw new TypeError('NotificationCard.opts.exitable must be a boolean.');
-						break;
-					case 'darken':
-						if (typeof options[option] == 'boolean') opts[option] = options[option];
-						else throw new TypeError('NotificationCard.opts.darken must be a boolean.');
-						break;
-					case 'onexit':
-						if (typeof options[option] == 'function') opts[option] = options[option];
-						else throw new TypeError('NotificationCard.opts.onexit must be a function.');
-						break;
-					default:
-						throw new ReferenceError('NotificationCard.opts: Unknown option ' + option);
-				}
+		// remove optional arguments that were explicitly stated as undefined or null, to allow for the spreading defaults to work
+		for (let key in options) {
+			if (key in options && options[key as keyof NotificationCardOptions] == undefined) {
+				delete options[key as keyof NotificationCardOptions];
 			}
 		}
+		
+		let opts: NotificationCardOptions = {
+			...defaultOpts,
+			...options,
+		};
+		
+		// for (let option in opts) {
+			
+		// 	if (options.hasOwnProperty(option)) {	
+		// 		switch(option){
+		// 			case 'type':
+		// 				if (typeof options[option] == 'string') opts[option] = options[option];
+		// 				else throw new TypeError('NotificationCard.opts.type must be string.');
+		// 				break;
+		// 			case 'ttl':
+		// 				if (typeof options[option] == 'number') opts[option] = options[option];
+		// 				else throw new TypeError('NotificationCard.opts.ttl must be a number.');
+		// 				break;
+		// 			case 'exitable':
+		// 				if (typeof options[option] == 'boolean') opts[option] = options[option];
+		// 				else throw new TypeError('NotificationCard.opts.exitable must be a boolean.');
+		// 				break;
+		// 			case 'darken':
+		// 				if (typeof options[option] == 'boolean') opts[option] = options[option];
+		// 				else throw new TypeError('NotificationCard.opts.darken must be a boolean.');
+		// 				break;
+		// 			case 'onexit':
+		// 				if (typeof options[option] == 'function') opts[option] = options[option];
+		// 				else throw new TypeError('NotificationCard.opts.onexit must be a function.');
+		// 				break;
+		// 			default:
+		// 				throw new ReferenceError('NotificationCard.opts: Unknown option ' + option);
+		// 		}
+		// 	}
+		// }
 		
 		//sort through type and set opts.color and opts.textColor
 		switch (opts.type) {
@@ -289,10 +299,10 @@ class NotificationCard{
 				opts.borderColor = 'rgb(84,0,0)';
 				opts.textColor = 'rgb(255,255,255)';
 				break;
-			default: 
-				opts.color = 'rgb(240,245,255)';
-				opts.borderColor = 'rgb(80,80,84)';
-				opts.textColor = 'rgb(0,0,0)';
+			default:
+				opts.color ||= 'rgb(240,245,255)';
+				opts.borderColor ||= 'rgb(80,80,84)';
+				opts.textColor ||= 'rgb(0,0,0)';
 		}
 		
 		return opts;
@@ -313,6 +323,14 @@ class NotificationCard{
 		enrichedText = NotificationCard._enrichWithSelfClosingTags(enrichedText.html(), '/n', '</br>');
 		// 2025-01-24, M.O'C: Added hyperlink enrichment ~ reverse Markdown order i.e., (http://www.example.com)[link text]
 		enrichedText = NotificationCard._enrichHyperlinkTags(enrichedText.html());
+		
+		if (this.opts.sprite) {
+			enrichedText = 
+			enrichedText.prepend(
+				$(document.createElement('span'))
+					.addClass('sprite sp-20 sp-inline sp-black sp-' + this.opts.sprite)
+			);
+		}
 
 		return enrichedText;
 	}
@@ -406,6 +424,7 @@ class NotificationCard{
 }
 
 class NotificationCardOptions {
+	sprite?: string;
 	type?: string|undefined|null;
 	ttl?: number|undefined|null;
 	exitable?: boolean|undefined|null;

--- a/primary/public-src/ts-bundled/scoutradioz.ts
+++ b/primary/public-src/ts-bundled/scoutradioz.ts
@@ -6,13 +6,35 @@ if(!$){
 }
 
 $(() => {
-	if (Cookies.get('accepted') != 'true') {
-		let cookiesMessage = new NotificationCard('Scoutradioz uses some cookies in order to operate. We do not use third party cookies or tracking cookies.',
-			{ttl: 0, exitable: true, onexit: function(){
-				Cookies.set('accepted', 'true', {expires: 1000});
-			}});
-		// cookiesMessage.show();	2021-08-03 JL: Disabled cookie message because we probably don't need to show the message for the time being
+	// Check if news has been sent from the server, and if so, display it
+	let newsUpdate = Cookies.get('news_update_to_display');
+	if (newsUpdate) {
+		let newsCard = new NotificationCard(newsUpdate, {
+			color: '#ffffff',
+			borderColor: '#ff8e24',
+			textColor: '#33231d',
+			sprite: 'info',
+			exitable: true,
+			ttl: 0,
+			onexit: () => {
+				// After user dismissed...
+				// Clear the newsUpdate string so it stops getting displayed by client
+				Cookies.remove('news_update_to_display');
+				// and set cookie as acknowledgment to the server that this specific news item was read and dismissed
+				Cookies.set('last_news_update_read', Cookies.get('news_update_id'));
+			}
+		});
+		newsCard.show();
 	}
+	
+	
+	// if (Cookies.get('accepted') != 'true') {
+	// 	let cookiesMessage = new NotificationCard('Scoutradioz uses some cookies in order to operate. We do not use third party cookies or tracking cookies.',
+	// 		{ttl: 0, exitable: true, onexit: function(){
+	// 			Cookies.set('accepted', 'true', {expires: 1000});
+	// 		}});
+	// 	// cookiesMessage.show();	2021-08-03 JL: Disabled cookie message because we probably don't need to show the message for the time being
+	// }
 	// JL TODO: Override Cookies.set() method to allow for a simple global cookie enable/disable switch?
 	//		We can't disable Cookies.org_key, but we can disable non necessary ones like report columns and the selected "Are you:" button on the chooseorg page
 	//		Possible text: "Before you reject the use of non-necessary cookies, please take a look at our cookie policy, where we explain what each is used for. We do not use third party cookies or tracking cookies."
@@ -266,7 +288,7 @@ function measureTime(cb: () => void) : number {
 }
 
 declare class Cookies {
-	static get(key: string): any;
-	static set(key: string, value: any, value2?: any): any;
+	static get(key: string): string;
+	static set(key: string, value: string, value2?: any): string;
 	static remove(key: string): void;
 }

--- a/primary/public-src/ts/bundle.d.ts
+++ b/primary/public-src/ts/bundle.d.ts
@@ -131,7 +131,7 @@ declare class NotificationCard {
      * @param {boolean} [options.exitable=false] Whether card has an exit button.
      * @param {function} [options.onexit=undefined] Callback for when a user clicks the exit button.
      */
-    constructor(text: string, options?: object);
+    constructor(text: string, options?: NotificationCardOptions);
     /**
      * Static method to create and return a new NotificationCard with specified options.
      * @param {String} text Text to display on notification card
@@ -181,13 +181,14 @@ declare class NotificationCard {
      * @param {Number} time (Optional) Fade-out card with given time interval. (Default: 0ms, no fade)
      */
     remove(time?: number): this;
-    _filterOptions(options: any): NotificationCardOptions;
+    _filterOptions(options: NotificationCardOptions): NotificationCardOptions;
     _enrichText(): JQuery;
     static _enrichHyperlinkTags(html: string): JQuery<HTMLSpanElement>;
     static _enrichWithClosingTags(html: string, key: string, openTag: string, closeTag: string): JQuery<HTMLSpanElement>;
     static _enrichWithSelfClosingTags(html: string, key: string, tag: string): JQuery<HTMLSpanElement>;
 }
 declare class NotificationCardOptions {
+    sprite?: string;
     type?: string | undefined | null;
     ttl?: number | undefined | null;
     exitable?: boolean | undefined | null;
@@ -306,7 +307,7 @@ declare function copyClipboardDom(text: string): void;
  */
 declare function measureTime(cb: () => void): number;
 declare class Cookies {
-    static get(key: string): any;
-    static set(key: string, value: any, value2?: any): any;
+    static get(key: string): string;
+    static set(key: string, value: string, value2?: any): string;
     static remove(key: string): void;
 }

--- a/primary/src/app.ts
+++ b/primary/src/app.ts
@@ -99,8 +99,6 @@ app.get('/*', (req, res, next) => {
 //Must be the very first app.use
 app.use(utilities.refreshTier);
 
-app.use(usefunctions.maintenanceMode);
-
 //Boilerplate setup
 app.set('views', path.join(__dirname, '..', 'views'));
 app.set('view engine', 'pug');
@@ -114,6 +112,9 @@ app.disable('x-powered-by');
 app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+
+// load platform settings, including maintenance mode and news, after cookie parsing
+app.use(usefunctions.loadPlatformSettings);
 
 //Internationalization
 //Must be before any other custom code

--- a/primary/src/helpers/usefunctions.ts
+++ b/primary/src/helpers/usefunctions.ts
@@ -20,7 +20,7 @@ DateTimeExtras.DATETIME_SHORTER = { month: 'numeric', day: 'numeric', hour: 'num
 
 class UseFunctions {
 	static async loadPlatformSettings(req: express.Request, res: express.Response, next: express.NextFunction) {
-		const platformSettings = await utilities.findOne('platformsettings', {}, {}, {allowCache: false});
+		const platformSettings = await utilities.findOne('platformsettings', {}, {}, {allowCache: true});
 		if (!platformSettings) return next(); // Just in case the db doesn't have this entry, just proceed so we don't break anything
 		
 		if (platformSettings.maintenance_mode) {

--- a/primary/views/manage/config/editform.pug
+++ b/primary/views/manage/config/editform.pug
@@ -31,6 +31,9 @@ block content
 			overflow: unset;
 			border: 1px solid black;
 			height: 700px;
+			/* so minimap doesn't layer over notification cards */
+			position: relative;
+			z-index: 0;
 		}
 		#jsonfield-mobile {
 			width: 100%;

--- a/scoutradioz-types/types.d.ts
+++ b/scoutradioz-types/types.d.ts
@@ -476,6 +476,23 @@ export declare interface WebPushKeys extends DbDocument {
 declare type PasswordItem = TBAApiHeaders | FIRSTApiHeaders | TBAWebhookSecret | WebPushKeys;
 
 /**
+ * Intended to be a single-entry collection
+ */
+export declare interface PlatformSettings {
+	/** Quick way to enable/disable maintenance mode on the whole site */
+	maintenance_mode: boolean;
+	/** Most recent update to display, to any user who hasn't seen it yet */
+	news: {
+		/** unique marker for a device to signify that it already got the message */
+		cookie_value: string;
+		/** string to display */
+		summary: string;
+		/** Don't display the news after this date */
+		expires: Date;
+	}
+}
+
+/**
  * Set of scouters for a pit scouting assignment. NOTE: primary/secondary are REQUIRED
  * @collection pitscouting
  * @interface PitScoutingSet
@@ -713,7 +730,7 @@ export declare interface UserAgent {
 /**
  * Possible collection names in the SR database.
  */
-export declare type CollectionName = 'aggranges'|'events'|'i18n'|'layout'|'matches'|'matchscouting'|'orgs'|'orgschemas'|'orgteamvalues'|'passwords'|'pitscouting'|'rankingpoints'|'rankings'|'roles'|'schemas'|'scoutingpairs'|'sessions'|'sveltesessions'|'teams'|'uploads'|'users';
+export declare type CollectionName = 'aggranges'|'events'|'i18n'|'layout'|'matches'|'matchscouting'|'orgs'|'orgschemas'|'orgteamvalues'|'passwords'|'pitscouting'|'platformsettings'|'rankingpoints'|'rankings'|'roles'|'schemas'|'scoutingpairs'|'sessions'|'sveltesessions'|'teams'|'uploads'|'users';
 /**
  * Gets the correct schema for the given collection name.
  */
@@ -729,6 +746,7 @@ export declare type CollectionSchema<colName extends CollectionName> =
 	colName extends 'orgteamvalues' ? OrgTeamValue :
 	colName extends 'passwords' ? any : // JL: With the way we type-annotate stuff, it's easier to declare items in passwords as 'any' and then just type annotate it because we manually guarantee these guys
 	colName extends 'pitscouting' ? PitScouting :
+	colName extends 'platformsettings' ? PlatformSettings :
 	colName extends 'rankingpoints' ? RankingPoints :
 	colName extends 'rankings' ? Ranking :
 	colName extends 'roles' ? Role :


### PR DESCRIPTION
Uses new 'platformsettings' collection, which i guess we could call a 'singleton' collection, with platform-wide metadata.

I tried a few months ago to add an environment variable for maintenance mode, but that didn't work because Lambda's function versioning system freezes environment variables. Setting a boolean toggle in the database makes it much easier, we've just gotta be careful not to accidentally leave maintenance_mode to true and then all drop dead 😁

News updates get shown to a device if it hasn't flagged the last_news_update_read cookie to the current db cookie value and if the news update hasn't passed its expiration date, then the client shows the notification at every page load until they dismiss it. Then it sets the cookie to acknowledge to the server that it's dismissed the notification.