### PR TITLE
Prevent falsy value errors from assert in calculate agg metrics

### DIFF
--- a/scoutradioz-helpers/src/matchdatahelper.ts
+++ b/scoutradioz-helpers/src/matchdatahelper.ts
@@ -586,11 +586,8 @@ export class MatchDataHelper {
 		);
 		// 2025-03-02, M.O'C: during webhook updates when multiple teams are at the same event,
 		// if one team's schema blows this assert then most or none of the teams get updated
-		try {
-			assert(orgschema);
-		}
-		catch (error) {
-			logger.error(`Caught ${error} for org_key=${org_key}, event_year=${event_year}, event_key=${event_key} - exiting function`);
+		if (!orgschema) {
+			logger.warn(`No orgschema for org_key=${org_key}, event_year=${event_year}, event_key=${event_key} - exiting`);
 			return;
 		}
 

--- a/scoutradioz-helpers/src/matchdatahelper.ts
+++ b/scoutradioz-helpers/src/matchdatahelper.ts
@@ -584,7 +584,16 @@ export class MatchDataHelper {
 			{},
 			{ allowCache: true, maxCacheAge: 180 }
 		);
-		assert(orgschema);
+		// 2025-03-02, M.O'C: during webhook updates when multiple teams are at the same event,
+		// if one team's schema blows this assert then most or none of the teams get updated
+		try {
+			assert(orgschema);
+		}
+		catch (error) {
+			logger.error(`Caught ${error} for org_key=${org_key}, event_year=${event_year}, event_key=${event_key} - exiting function`);
+			return;
+		}
+
 		const schema = await utilities.findOne('schemas',
 			{ _id: orgschema.schema_id, },
 			{},


### PR DESCRIPTION
During competitions, at some events where multiple orgs are set to "current event" sometimes one of those orgs has an orgschema which doesn't return from the DB call.

With the previous "assert(orgschema)", the calling code [with its array of 'Promises' to await on] would be aborted early.

We don't need to throw an error, so instead we're logging as a warning & exiting early.