### PR TITLE
Fix missing data causing na ns in derived metrics

### DIFF
--- a/primary/views/reports/teamintel.pug
+++ b/primary/views/reports/teamintel.pug
@@ -180,6 +180,8 @@ block content
 				if (matches && matches.length > 0)		
 					h6.i!=msg('reports.teamMatchClick')
 					h6.i!=msg('reports.overallMatchClick')
+					h6(class="theme-text")
+						a(class="theme-link w3-btn" href="/reports/teamdata?team_key=" + team.key)!=msg('reports.teamAllMatchData', {team: team.key.substring(3)})
 					hr 
 					
 					each match in matches

--- a/primary/views/reports/teamintel.pug
+++ b/primary/views/reports/teamintel.pug
@@ -38,6 +38,8 @@ block content
 					a(href=images.b.lg)
 						img(src=images.b.sm alt="" class="w3-image team-image-sm")
 		div(class="w3-padding")
+			a(class="theme-link w3-btn" href="/reports/teamdata?team_key=" + team.key)!=msg('reports.teamAllMatchData', {team: team.key.substring(3)})
+		div(class="w3-padding")
 			a(class="theme-link w3-btn" href=`/reports/upcoming?team_key=${team.key}`)!=msg('reports.upcomingMatchesTeam', {team: teamNum})
 		div(class="w3-padding")
 			a(class="theme-link w3-btn" href=`/reports/teamintelhistory?team_key=${team.key}`)!=msg('reports.teamDataYear', {team: teamNum})
@@ -178,8 +180,6 @@ block content
 				if (matches && matches.length > 0)		
 					h6.i!=msg('reports.teamMatchClick')
 					h6.i!=msg('reports.overallMatchClick')
-					h6(class="theme-text")
-						a(class="theme-link w3-btn" href="/reports/teamdata?team_key=" + team.key)!=msg('reports.teamAllMatchData', {team: team.key.substring(3)})
 					hr 
 					
 					each match in matches

--- a/scoutradioz-helpers/src/matchdatahelper.ts
+++ b/scoutradioz-helpers/src/matchdatahelper.ts
@@ -460,8 +460,10 @@ export class MatchDataHelper {
 					tparse += parse;
 					tresolve += resolve;
 				}
-				catch {
-					matchData[thisItem.id] = NaN;
+				catch (err) {
+					//matchData[thisItem.id] = NaN;
+					logger.trace(`${err} - thisItem.id ${thisItem.id} previously was NaN'd`);
+					delete matchData[thisItem.id];
 				}
 			}
 			// Legacy format


### PR DESCRIPTION
1. Ultimately opted to have 'formulas' just **not** write a data attribute if the value would otherwise be NaN due to catching an error
2. Also included duplicating the "Match scouting data for team NNNN matches" button to a more prominent/convenient position on the Team Intel page (outside of the twisties)