### PR TITLE
Fix sst deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 	},
 	"dependencies": {
 		"archiver": "^5.3.0",
-		"aws-sdk": "^2.1066.0",
 		"colors": "^1.4.0",
 		"concat-stream": "^2.0.0",
 		"esbuild-svelte": "^0.9.3",

--- a/primary/package.json
+++ b/primary/package.json
@@ -86,7 +86,7 @@
 		"scoutradioz-utilities": "file:../scoutradioz-utilities",
 		"serve-favicon": "^2.5.0",
 		"smui-theme": "^8.0.3",
-		"sst": "^3.7.9",
+		"sst": "^4.9.1",
 		"web-push": "^3.4.5"
 	},
 	"nodemonConfig": {

--- a/primary/public-src/sst-env.d.ts
+++ b/primary/public-src/sst-env.d.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 /* deno-fmt-ignore-file */
+/* biome-ignore-all lint: auto-generated */
 
 /// <reference path="../sst-env.d.ts" />
 

--- a/primary/sst-env.d.ts
+++ b/primary/sst-env.d.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 /* deno-fmt-ignore-file */
+/* biome-ignore-all lint: auto-generated */
 
 declare module "sst" {
   export interface Resource {

--- a/primary/sst.config.ts
+++ b/primary/sst.config.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference path="./.sst/platform/config.d.ts" />
 
+function throw_err(msg: string): never {
+	console.log('ERROR: ' + msg);
+	throw new Error(msg);
+}
+
 export default $config({
 	app(input) {
 		return {
@@ -20,14 +25,14 @@ export default $config({
 		console.log('Git commit hash:', gitHash);
 		console.log('Stage:', $app.stage);
 		if ($dev && $app.stage !== 'dev') {
-			throw new Error('Dev mode only allowed on "dev" tier!');
+			throw_err('Dev mode only allowed on "dev" tier!');
 		}
 		// only enforce requirements when deploying
 		if (!$dev) {
 			if (!['prod', 'qa', 'test'].includes($app.stage))
-				throw new Error('app.stage must be prod, qa, or test');
+				throw_err('app.stage must be prod, qa, or test');
 			if (!gitHash)
-				throw new Error('git hash must be specified via an environment variable HASH=$(git rev-parse HEAD)');
+				throw_err('git hash must be specified via an environment variable HASH=$(git rev-parse HEAD)');
 		}
 
 		let domain, sr_hostname;


### PR DESCRIPTION
I think updating the sst version fixed the weird syntax issue we were having.
I updated the pre-deploy checks to print the error to the console first, to avoid "an unknown error occurred" messages when we're actually deploying it wrong, i.e., wrong stage name or git hash not provided.